### PR TITLE
Update protobuf and gRPC in the C# library

### DIFF
--- a/csharp-libraries/Nanover.Protocol/Nanover.Protocol.csproj
+++ b/csharp-libraries/Nanover.Protocol/Nanover.Protocol.csproj
@@ -6,9 +6,9 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.4.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.10.1" />
-    <PackageReference Include="Grpc" Version="2.25.0" />
-    <PackageReference Include="Grpc.Tools" Version="1.19.0" PrivateAssets="All" />
+    <PackageReference Include="Google.Protobuf" Version="3.18.0" />
+    <PackageReference Include="Grpc.Net.Client" Version="2.52.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.40.0" PrivateAssets="All" />
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.1" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />


### PR DESCRIPTION
These are the changes required to build the GRPC dlls for NanoVer iMD.