### PR TITLE
Use standard scale for spring constant k in spring force

### DIFF
--- a/python-libraries/nanover-core/src/nanover/imd/imd_force.py
+++ b/python-libraries/nanover-core/src/nanover/imd/imd_force.py
@@ -219,7 +219,7 @@ def calculate_gaussian_force(
 def calculate_spring_force(
     particle_position: npt.NDArray,
     interaction_position: npt.NDArray,
-    k=1,
+    k=2,
     periodic_box_lengths: Optional[npt.NDArray] = None,
 ) -> Tuple[float, npt.NDArray]:
     """
@@ -238,9 +238,9 @@ def calculate_spring_force(
     g = interaction_position
 
     diff, dist_sqr = _calculate_diff_and_sqr_distance(r, g, periodic_box_lengths)
-    energy = k * dist_sqr
+    energy = 0.5 * k * dist_sqr
     # force is negative derivative of energy wrt to position.
-    force = (-2 * k) * diff
+    force = -k * diff
     return energy, force
 
 


### PR DESCRIPTION
For whatever reason our spring interaction equations were out by a factor of two, meaning that our spring constant k is actually corresponds to 2x the spring constant in the standard form (http://hyperphysics.phy-astr.gsu.edu/hbase/pespr.html). Adjusting the default constant to 2 retains the same energy/force when k is not specified (which is all cases, as far as I can tell). 