### PR TITLE
Self-terminate OSC client when frames aren't subscribed

### DIFF
--- a/python-libraries/prototypes/osc/osc_client.py
+++ b/python-libraries/prototypes/osc/osc_client.py
@@ -32,6 +32,9 @@ class OscClient:
 
     def run(self):
         for dt in yield_interval(self.send_interval):
+            if not self.nanover_client.are_frames_subscribed:
+                break
+
             frame = self.nanover_client.latest_frame
             if frame is not None:
                 self.process_frame(frame)


### PR DESCRIPTION
The warning is because the client tries to run forever even when the test has cleaned up the client.