### PR TITLE
Clean up strange autoconnect test

### DIFF
--- a/python-libraries/nanover-core/tests/test_autoconnect.py
+++ b/python-libraries/nanover-core/tests/test_autoconnect.py
@@ -106,7 +106,8 @@ def test_autoconnect_separate_servers(broadcastable_servers):
     Tests that an iMD application running on multiple separate servers on multiple ports is discoverable
     and that the client connects to it in the expected way.
     """
-    # Use unique non-default port for discovery
+    # Use unique non-default port for discovery. This avoids interference
+    # with other tests and other servers on the network.
     DISCOVERY_PORT = BROADCAST_PORT + 2
     frame_server, imd_server, multiplayer_server = broadcastable_servers
 

--- a/python-libraries/nanover-core/tests/test_autoconnect.py
+++ b/python-libraries/nanover-core/tests/test_autoconnect.py
@@ -39,7 +39,8 @@ def discoverable_imd_server():
     """
     Returns a discoverable iMD server on a free port, discoverable on a non-default ESSD port.
     """
-    # Use unique non-default port for discovery
+    # Use unique non-default port for discovery. This avoids interference
+    # with other tests and other servers on the network.
     DISCOVERY_PORT = BROADCAST_PORT + 1
     address = get_broadcastable_ip()
     server = NanoverServer(address=address, port=0)


### PR DESCRIPTION
May not be the direct cause of any failure, but this test is weird: there's a duplicate fixture, duplicate words in the docstring, and it starts two servers. Some kind of weird merge failure?