### PR TITLE
restore xfail test that may now work

### DIFF
--- a/python-libraries/nanover-ase/tests/openmm_ase/test_ase_runner.py
+++ b/python-libraries/nanover-ase/tests/openmm_ase/test_ase_runner.py
@@ -87,7 +87,6 @@ def test_from_xml(serialized_simulation_path, imd_params):
 
 
 @pytest.mark.serial
-@pytest.mark.xfail(reason="Issue https://github.com/IRL2/nanover-protocol/issues/48")
 def test_defaults(default_runner):
     runner = default_runner
     default_params = ImdParams()


### PR DESCRIPTION
Tests marked `serial` weren't actually being run independently (https://github.com/IRL2/nanover-protocol/pull/77#discussion_r1561068075), so it may be the case that this test is fine now.

Closes https://github.com/IRL2/nanover-protocol/issues/48