### PR TITLE
pass-early delayed assert

### DIFF
--- a/python-libraries/conftest.py
+++ b/python-libraries/conftest.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite("nanover.testing")

--- a/python-libraries/nanover-core/src/nanover/testing/__init__.py
+++ b/python-libraries/nanover-core/src/nanover/testing/__init__.py
@@ -1,0 +1,1 @@
+from .asserts import assert_in_soon, assert_equal_soon, assert_not_in_soon

--- a/python-libraries/nanover-core/src/nanover/testing/asserts.py
+++ b/python-libraries/nanover-core/src/nanover/testing/asserts.py
@@ -1,0 +1,26 @@
+import time
+from typing import Callable
+
+
+def assert_equal_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
+    __tracebackhide__ = True
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and a() != b():
+        time.sleep(interval)
+    assert a() == b()
+
+
+def assert_in_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
+    __tracebackhide__ = True
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and a() not in b():
+        time.sleep(interval)
+    assert a() in b()
+
+
+def assert_not_in_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
+    __tracebackhide__ = True
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline and a() in b():
+        time.sleep(interval)
+    assert a() not in b()

--- a/python-libraries/nanover-core/src/nanover/testing/asserts.py
+++ b/python-libraries/nanover-core/src/nanover/testing/asserts.py
@@ -3,7 +3,7 @@ from typing import Callable
 
 
 def assert_equal_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
-    __tracebackhide__ = True
+    __tracebackhide__ = True  # hide this function in the test traceback
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline and a() != b():
         time.sleep(interval)
@@ -11,7 +11,7 @@ def assert_equal_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
 
 
 def assert_in_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
-    __tracebackhide__ = True
+    __tracebackhide__ = True  # hide this function in the test traceback
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline and a() not in b():
         time.sleep(interval)
@@ -19,7 +19,7 @@ def assert_in_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
 
 
 def assert_not_in_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
-    __tracebackhide__ = True
+    __tracebackhide__ = True  # hide this function in the test traceback
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline and a() in b():
         time.sleep(interval)

--- a/python-libraries/nanover-core/src/nanover/testing/py.typed
+++ b/python-libraries/nanover-core/src/nanover/testing/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/python-libraries/nanover-core/tests/imd/test_imd_client.py
+++ b/python-libraries/nanover-core/tests/imd/test_imd_client.py
@@ -1,6 +1,4 @@
 import itertools
-import time
-from typing import Callable
 
 import pytest
 from nanover.imd.particle_interaction import ParticleInteraction
@@ -9,35 +7,12 @@ from nanover.imd.imd_state import (
     interaction_to_dict,
     dict_to_interaction,
 )
+from nanover.testing import assert_in_soon, assert_not_in_soon, assert_equal_soon
 from nanover.utilities.change_buffers import DictionaryChange
 
 from .test_imd_server import imd_server_client, imd_server, interaction
 
 IMMEDIATE_REPLY_WAIT_TIME = 0.01
-
-
-def assert_equal_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
-    __tracebackhide__ = True
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline and a() != b():
-        time.sleep(interval)
-    assert a() == b()
-
-
-def assert_in_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
-    __tracebackhide__ = True
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline and a() not in b():
-        time.sleep(interval)
-    assert a() in b()
-
-
-def assert_not_in_soon(a: Callable, b: Callable, interval=0.1, timeout=1.0):
-    __tracebackhide__ = True
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline and a() in b():
-        time.sleep(interval)
-    assert a() not in b()
 
 
 def test_start_interaction(imd_server_client):

--- a/python-libraries/nanover-core/tests/imd/test_imd_client.py
+++ b/python-libraries/nanover-core/tests/imd/test_imd_client.py
@@ -193,5 +193,5 @@ def test_interactions_property(imd_server_client):
 
     imd_client.subscribe_all_state_updates(interval=0)
     assert_equal_soon(
-        lambda: imd_client.interactions.keys(), lambda: real_interactions.keys()
+        imd_client.interactions.keys, real_interactions.keys
     )


### PR DESCRIPTION
We have a lot of tests that depend on waiting for threaded/network activity to happen in a timely fashion. The longer we wait before asserting, the more reliable the test, but the longer the entire suite will take. This is a possible pattern we could use to only wait as long as necessary.

It would require corresponding functions for not equals, in, not in, etc. Not sure if it could be made any cleaner. Also not sure how to make a module available to the tests without just putting it in `nanover.core`.

This might just be a bad approach, but I present it here as an option to discuss.

Closes https://github.com/IRL2/nanover-protocol/issues/46