### PR TITLE
Fixed visualisation tutorial

### DIFF
--- a/examples/fundamentals/visualisations.ipynb
+++ b/examples/fundamentals/visualisations.ipynb
@@ -58,10 +58,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from nanover.ase.openmm import OpenMMIMDRunner\n",
+    "from nanover.ase.openmm import ASEOpenMMRunner\n",
     "\n",
     "# Start a NanoVer server given the simulation\n",
-    "server = OpenMMIMDRunner(simulation)\n",
+    "server = ASEOpenMMRunner(simulation)\n",
     "\n",
     "# Print what port the server is running on\n",
     "print(\"Server running on port {0}\".format(server.port))\n",
@@ -1316,7 +1316,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1330,7 +1330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.12.0"
   },
   "pycharm": {
    "stem_cell": {
@@ -1343,5 +1343,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 4
 }

--- a/examples/fundamentals/visualisations.ipynb
+++ b/examples/fundamentals/visualisations.ipynb
@@ -74,14 +74,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We now have a server running on the given port. By starting up NanoVer iMD, you can now connect to this server either by using the autoconnect feature, or by manually typing in the port and address (you can use either `localhost` or `127.0.0.1`, both of which represent your local machine)"
+    "We now have a server running on the given port. By starting up the NanoVer iMD-VR client, you can now connect to this server either by using the autoconnect feature, the discovery feature, or by manually typing in the port and address (you can use either `localhost` or `127.0.0.1`, both of which represent your local machine)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Connecting to the server will present you with a simulation of Neuraminidase, drawn using the standard ball and stick approach. The coloring by default is **CPK**, which colors hydrogens, carbons, oxygens and nitrogens white, grey, red and blue respectively."
+    "Connecting a VR client to the server will present you with a simulation of Neuraminidase, drawn using the standard ball and stick approach. The coloring by default is **CPK**, which colors hydrogens, carbons, oxygens and nitrogens white, grey, red and blue respectively."
    ]
   },
   {


### PR DESCRIPTION
This PR is concerned with fixing the visualisations.ipynb notebook in the examples/fundamentals directory to:
- Replace the depreciated "OpenMMIMDRunner" with "ASEOpenMMRunner" (addressing Issue #113 )
- Add text to make it more clear that the visualisations in the tutorial are those seen in the VR client (it was not apparent to me that these visualisations were VR-client specific, so hopefully these additions will clarify that)
- Added text to indicate the ability to connect to the server via the discovery feature

Comments, suggestions and improvements welcomed and encouraged! 