### PR TITLE
fix port sharing for mac

### DIFF
--- a/python-libraries/nanover-essd/src/nanover/essd/client.py
+++ b/python-libraries/nanover-essd/src/nanover/essd/client.py
@@ -7,27 +7,11 @@ import time
 from typing import Optional, Set, Iterable
 
 import select
-from socket import socket, AF_INET, SOCK_DGRAM
-from _socket import SO_REUSEADDR, SO_REUSEPORT, SOL_SOCKET
 
-from nanover.essd.server import BROADCAST_PORT
+from nanover.essd.server import BROADCAST_PORT, configure_reusable_socket
 from nanover.essd.servicehub import ServiceHub, MAXIMUM_MESSAGE_SIZE
 
 IP_ADDRESS_ANY = "0.0.0.0"
-
-
-def configure_reusable_socket() -> socket:
-    """
-    Sets up a socket set up for listening with reuseable address.
-
-    :return: A socket.
-    """
-    # IPv4 UDP socket
-    s = socket(AF_INET, SOCK_DGRAM)
-    # Enable reuse
-    s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
-    s.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1)
-    return s
 
 
 class DiscoveryClient:

--- a/python-libraries/nanover-essd/src/nanover/essd/client.py
+++ b/python-libraries/nanover-essd/src/nanover/essd/client.py
@@ -7,11 +7,26 @@ import time
 from typing import Optional, Set, Iterable
 
 import select
+from socket import socket, AF_INET, SOCK_DGRAM
+from _socket import SO_REUSEADDR, SOL_SOCKET
 
-from nanover.essd.server import BROADCAST_PORT, configure_reusable_socket
+from nanover.essd.server import BROADCAST_PORT
 from nanover.essd.servicehub import ServiceHub, MAXIMUM_MESSAGE_SIZE
 
 IP_ADDRESS_ANY = "0.0.0.0"
+
+
+def configure_reusable_socket() -> socket:
+    """
+    Sets up a socket set up for listening with reuseable address.
+
+    :return: A socket.
+    """
+    # IPv4 UDP socket
+    s = socket(AF_INET, SOCK_DGRAM)
+    # Enable reuse
+    s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+    return s
 
 
 class DiscoveryClient:

--- a/python-libraries/nanover-essd/src/nanover/essd/client.py
+++ b/python-libraries/nanover-essd/src/nanover/essd/client.py
@@ -8,7 +8,7 @@ from typing import Optional, Set, Iterable
 
 import select
 from socket import socket, AF_INET, SOCK_DGRAM
-from _socket import SO_REUSEADDR, SOL_SOCKET
+from _socket import SO_REUSEADDR, SO_REUSEPORT, SOL_SOCKET
 
 from nanover.essd.server import BROADCAST_PORT
 from nanover.essd.servicehub import ServiceHub, MAXIMUM_MESSAGE_SIZE
@@ -26,6 +26,7 @@ def configure_reusable_socket() -> socket:
     s = socket(AF_INET, SOCK_DGRAM)
     # Enable reuse
     s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+    s.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1)
     return s
 
 

--- a/python-libraries/nanover-essd/src/nanover/essd/server.py
+++ b/python-libraries/nanover-essd/src/nanover/essd/server.py
@@ -17,7 +17,7 @@ Example
 import logging
 import threading
 import time
-from socket import socket, AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST, SO_REUSEADDR, SO_REUSEPORT
+from socket import socket, AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST, SO_REUSEADDR
 from typing import Optional, Dict, List
 
 from nanover.essd.utils import (
@@ -42,7 +42,14 @@ def configure_reusable_socket() -> socket:
     # Enable broadcasting
     s.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
     s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
-    s.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1)
+
+    try:
+        from socket import SO_REUSEPORT
+
+        s.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1)
+    except ImportError:
+        pass
+
     return s
 
 

--- a/python-libraries/nanover-essd/src/nanover/essd/server.py
+++ b/python-libraries/nanover-essd/src/nanover/essd/server.py
@@ -43,7 +43,7 @@ def configure_reusable_socket() -> socket:
     s.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
     s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
 
-    # Necessary for multiple client on Mac, but doesn't exist on Windows
+    # Necessary for multiple client on Mac, acceptable on Linux, but doesn't exist on Windows.
     try:
         from socket import SO_REUSEPORT
 

--- a/python-libraries/nanover-essd/src/nanover/essd/server.py
+++ b/python-libraries/nanover-essd/src/nanover/essd/server.py
@@ -17,7 +17,7 @@ Example
 import logging
 import threading
 import time
-from socket import socket, AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST, SO_REUSEADDR
+from socket import socket, AF_INET, SOCK_DGRAM, SOL_SOCKET, SO_BROADCAST, SO_REUSEADDR, SO_REUSEPORT
 from typing import Optional, Dict, List
 
 from nanover.essd.utils import (
@@ -42,6 +42,7 @@ def configure_reusable_socket() -> socket:
     # Enable broadcasting
     s.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
     s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
+    s.setsockopt(SOL_SOCKET, SO_REUSEPORT, 1)
     return s
 
 

--- a/python-libraries/nanover-essd/src/nanover/essd/server.py
+++ b/python-libraries/nanover-essd/src/nanover/essd/server.py
@@ -43,6 +43,7 @@ def configure_reusable_socket() -> socket:
     s.setsockopt(SOL_SOCKET, SO_BROADCAST, 1)
     s.setsockopt(SOL_SOCKET, SO_REUSEADDR, 1)
 
+    # Necessary for multiple client on Mac, but doesn't exist on Windows
     try:
         from socket import SO_REUSEPORT
 


### PR DESCRIPTION
Seems Mac changed at some point and now requires `SO_REUSEPORT` enabled to allow multiple clients listening on the same socket.

FIxes https://github.com/IRL2/nanover-protocol/issues/96