### PR TITLE
Test yield_interval, improve accuracy, fix bugged behavior

### DIFF
--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -33,10 +33,10 @@ class VariableIntervalGenerator:
 
 def yield_interval(interval: float):
     """
-    Yield at a set interval, accounting for the time spent outside of this
-    function.
+    Spend interval time between re-entering this generator and yielding again.
 
-    :param interval: Number of seconds to put between yields
+    :param interval: Number of seconds to put between re-entry and yielding
+    :yield: Number of seconds spent inside this function
     """
     last_yield = time.monotonic() - interval
     while True:

--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -22,26 +22,22 @@ class VariableIntervalGenerator:
             self._interval = value
 
     def yield_interval(self):
-        last_yield = time.monotonic() - self.interval
+        yield 0
         while True:
-            time_since_yield = time.monotonic() - last_yield
-            wait_duration = max(0.0, self.interval - time_since_yield)
-            time.sleep(wait_duration)
-            yield time.monotonic() - last_yield
             last_yield = time.monotonic()
+            time.sleep(self.interval)
+            yield time.monotonic() - last_yield
 
 
 def yield_interval(interval: float):
     """
-    Spend interval time between re-entering this generator and yielding again.
+    Yield immediately then sleep for a specified time between each subsequent yield.
 
-    :param interval: Number of seconds to put between re-entry and yielding
-    :yield: Number of seconds spent inside this function
+    :param interval: Number of seconds to sleep
+    :yield: Number of seconds actually spent sleeping
     """
-    last_yield = time.monotonic() - interval
+    yield 0
     while True:
-        time_since_yield = time.monotonic() - last_yield
-        wait_duration = max(0.0, interval - time_since_yield)
-        time.sleep(wait_duration)
-        yield time.monotonic() - last_yield
         last_yield = time.monotonic()
+        time.sleep(interval)
+        yield time.monotonic() - last_yield

--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -22,22 +22,30 @@ class VariableIntervalGenerator:
             self._interval = value
 
     def yield_interval(self):
+        prev_yield = time.monotonic()
         yield 0
         while True:
-            last_yield = time.monotonic()
-            time.sleep(self.interval)
-            yield time.monotonic() - last_yield
+            time_since_yield = time.monotonic() - prev_yield
+            wait_duration = max(0.0, self.interval - time_since_yield)
+            time.sleep(wait_duration)
+            next_yield = time.monotonic()
+            yield next_yield - prev_yield
+            prev_yield = next_yield
 
 
 def yield_interval(interval: float):
     """
-    Yield immediately then sleep for a specified time between each subsequent yield.
+    Yield immediately and then every interval seconds, yielding the time in seconds that passed between yields.
 
-    :param interval: Number of seconds to sleep
-    :yield: Number of seconds actually spent sleeping
+    :param interval: Number of seconds to ensure between yields
+    :yield: Number of seconds since last yielding
     """
+    prev_yield = time.monotonic()
     yield 0
     while True:
-        last_yield = time.monotonic()
-        time.sleep(interval)
-        yield time.monotonic() - last_yield
+        time_since_yield = time.monotonic() - prev_yield
+        wait_duration = max(0.0, interval - time_since_yield)
+        time.sleep(wait_duration)
+        next_yield = time.monotonic()
+        yield next_yield - prev_yield
+        prev_yield = next_yield

--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -22,13 +22,13 @@ class VariableIntervalGenerator:
             self._interval = value
 
     def yield_interval(self):
-        prev_yield = time.monotonic()
+        prev_yield = time.perf_counter()
         yield 0
         while True:
-            time_since_yield = time.monotonic() - prev_yield
+            time_since_yield = time.perf_counter() - prev_yield
             wait_duration = max(0.0, self.interval - time_since_yield)
             time.sleep(wait_duration)
-            next_yield = time.monotonic()
+            next_yield = time.perf_counter()
             yield next_yield - prev_yield
             prev_yield = next_yield
 
@@ -40,12 +40,12 @@ def yield_interval(interval: float):
     :param interval: Number of seconds to ensure between yields
     :yield: Number of seconds since last yielding
     """
-    prev_yield = time.monotonic()
+    prev_yield = time.perf_counter()
     yield 0
     while True:
-        time_since_yield = time.monotonic() - prev_yield
+        time_since_yield = time.perf_counter() - prev_yield
         wait_duration = max(0.0, interval - time_since_yield)
         time.sleep(wait_duration)
-        next_yield = time.monotonic()
+        next_yield = time.perf_counter()
         yield next_yield - prev_yield
         prev_yield = next_yield

--- a/python-libraries/nanover-core/tests/test_frame_server.py
+++ b/python-libraries/nanover-core/tests/test_frame_server.py
@@ -10,6 +10,8 @@ from nanover.trajectory import FrameServer, FrameClient, FrameData
 from nanover.trajectory.frame_data import SERVER_TIMESTAMP
 from numpy import average
 
+from .utilities.test_timing import TIMING_TOLERANCE, COMMON_INTERVALS
+
 SUBSCRIBE_METHODS = ("subscribe_frames_async", "subscribe_last_frames_async")
 FRAME_DATA_VARIABLE_KEYS = (SERVER_TIMESTAMP,)
 IMMEDIATE_REPLY_WAIT_TIME = 0.01
@@ -334,7 +336,7 @@ def test_subscribe_latest_frames_aggregates_frames(
 
 
 @pytest.mark.parametrize("subscribe_method", SUBSCRIBE_METHODS)
-@pytest.mark.parametrize("frame_interval", (1 / 10, 1 / 30, 1 / 60))
+@pytest.mark.parametrize("frame_interval", COMMON_INTERVALS)
 def test_subscribe_frames_frame_interval(
     frame_server_client_pair, simple_frame_data, subscribe_method, frame_interval
 ):
@@ -345,7 +347,6 @@ def test_subscribe_frames_frame_interval(
     frame_server, frame_client = frame_server_client_pair
     subscribe_frames_async = getattr(frame_client, subscribe_method)
 
-    tolerance = 5 / 1000  # 5 milliseconds
     frame_limit = 30
     time_limit = frame_limit * frame_interval * 1.5
     receive_times = []
@@ -365,4 +366,4 @@ def test_subscribe_frames_frame_interval(
     intervals = [
         receive_times[i + 1] - receive_times[i] for i in range(frame_limit - 1)
     ]
-    assert abs(average(intervals) - frame_interval) < tolerance
+    assert average(intervals) - frame_interval == pytest.approx(0, abs=TIMING_TOLERANCE)

--- a/python-libraries/nanover-core/tests/test_frame_server.py
+++ b/python-libraries/nanover-core/tests/test_frame_server.py
@@ -2,6 +2,7 @@ from typing import Iterable
 from contextlib import contextmanager
 from unittest.mock import Mock
 
+import numpy
 import pytest
 import time
 
@@ -363,7 +364,5 @@ def test_subscribe_frames_frame_interval(
     frame_server.send_frame(0, simple_frame_data)
 
     time.sleep(time_limit)
-    intervals = [
-        receive_times[i + 1] - receive_times[i] for i in range(frame_limit - 1)
-    ]
-    assert average(intervals) - frame_interval == pytest.approx(0, abs=TIMING_TOLERANCE)
+    intervals = numpy.diff(receive_times)
+    assert average(intervals) == pytest.approx(frame_interval, abs=TIMING_TOLERANCE)

--- a/python-libraries/nanover-core/tests/utilities/test_timing.py
+++ b/python-libraries/nanover-core/tests/utilities/test_timing.py
@@ -65,8 +65,7 @@ def test_yield_interval_delays_dt(interval, delay):
     reported_deltas = [
         monitor_delay(dt) for dt in itertools.islice(yield_interval(interval), count)
     ]
+    yield_times.append(time.monotonic())
     measured_deltas = [yield_times[i] - enter_times[i] for i in range(count)]
 
-    assert reported_deltas[1:] == pytest.approx(
-        measured_deltas[1:], abs=TIMING_TOLERANCE
-    )
+    assert reported_deltas == pytest.approx(measured_deltas, abs=TIMING_TOLERANCE)

--- a/python-libraries/nanover-core/tests/utilities/test_timing.py
+++ b/python-libraries/nanover-core/tests/utilities/test_timing.py
@@ -23,7 +23,7 @@ def test_yield_interval(interval, work_factor):
     count = round(1 / interval)
 
     for dt in itertools.islice(yield_interval(interval), count):
-        times.append(time.monotonic())
+        times.append(time.perf_counter())
         time.sleep(interval * work_factor)
 
     intervals = numpy.diff(times)
@@ -41,12 +41,11 @@ def test_yield_interval_dt(interval, work_factor):
     reported_deltas = []
     count = round(1 / interval)
 
-    times.append(time.monotonic())
+    times.append(time.perf_counter())
     for dt in itertools.islice(yield_interval(interval), count):
         reported_deltas.append(dt)
-        times.append(time.monotonic())
+        times.append(time.perf_counter())
         time.sleep(interval * work_factor)
 
     measured_deltas = numpy.diff(times)
-
     assert reported_deltas == pytest.approx(measured_deltas, abs=TIMING_TOLERANCE)

--- a/python-libraries/nanover-core/tests/utilities/test_timing.py
+++ b/python-libraries/nanover-core/tests/utilities/test_timing.py
@@ -1,0 +1,72 @@
+import time
+
+import pytest
+import itertools
+
+from numpy import average
+
+from nanover.utilities.timing import yield_interval
+
+TIMING_TOLERANCE = 0.005  # 5ms
+COMMON_INTERVALS = (1 / 10, 1 / 30, 1 / 60)
+
+
+@pytest.mark.parametrize("interval", COMMON_INTERVALS)
+def test_yield_interval(interval):
+    """
+    Test that yield_interval yields on average at the correct interval.
+    """
+    count = round(1 / interval)
+    times = [
+        time.monotonic() for _ in itertools.islice(yield_interval(interval), count)
+    ]
+    intervals = [times[i] - times[i - 1] for i in range(1, len(times))]
+    assert average(intervals) == pytest.approx(interval, abs=TIMING_TOLERANCE)
+
+
+@pytest.mark.parametrize("interval", COMMON_INTERVALS)
+@pytest.mark.parametrize("delay", (0.5, 0.1, 0.01))
+def test_yield_interval_delays(interval, delay):
+    """
+    Test that yield_interval does not yield any faster if more time is spent outside of it.
+    """
+
+    def do_delay():
+        time.sleep(delay)
+        return time.monotonic()
+
+    # try not to test for longer than 1s but do at least 3 yields
+    count = max(3, round(1 / (interval + delay)))
+    times = [do_delay() for _ in itertools.islice(yield_interval(interval), count)]
+    intervals = [times[i] - times[i - 1] for i in range(1, len(times))]
+    assert average(intervals) == pytest.approx(interval + delay, abs=TIMING_TOLERANCE)
+
+
+@pytest.mark.parametrize("interval", COMMON_INTERVALS)
+@pytest.mark.parametrize("delay", (0.5, 0.1, 0.01))
+def test_yield_interval_delays_dt(interval, delay):
+    """
+    Test that yield_interval yields only the time spent inside itself.
+    """
+
+    # try not to test for longer than 1s but do at least 3 yields
+    count = max(3, round(1 / (interval + delay)))
+
+    yield_times = []
+    enter_times = []
+
+    def monitor_delay(dt):
+        yield_times.append(time.monotonic())
+        time.sleep(delay)
+        enter_times.append(time.monotonic())
+        return dt
+
+    enter_times.append(time.monotonic())
+    reported_deltas = [
+        monitor_delay(dt) for dt in itertools.islice(yield_interval(interval), count)
+    ]
+    measured_deltas = [yield_times[i] - enter_times[i] for i in range(count)]
+
+    assert reported_deltas[1:] == pytest.approx(
+        measured_deltas[1:], abs=TIMING_TOLERANCE
+    )

--- a/python-libraries/nanover-openmm/src/nanover/openmm/runner.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/runner.py
@@ -295,7 +295,7 @@ class OpenMMRunner(NanoverRunner):
                     self.simulation.step(steps_for_this_iteration)
                 except (ValueError, openmm.OpenMMException):
                     # We want to stop running if the simulation exploded in a way
-                    # that prevents OpenMM to run. Otherwise, we will be a a state
+                    # that prevents OpenMM to run. Otherwise, we will be a state
                     # where OpenMM raises an exception which would make the runner
                     # unusable. The OpenMMException is typically raised by OpenMM
                     # itself when something is NaN; the ValueError is typically
@@ -304,7 +304,7 @@ class OpenMMRunner(NanoverRunner):
                 remaining_steps -= steps_for_this_iteration
             self._cancelled = False
         except Exception as err:
-            print(f"Error whith run: {err}")
+            print(f"Error with run: {err}")
 
     def step(self):
         with self._cancel_lock:

--- a/python-libraries/nanover-openmm/tests_nanover_openmm/test_runner.py
+++ b/python-libraries/nanover-openmm/tests_nanover_openmm/test_runner.py
@@ -498,4 +498,6 @@ class TestRunner:
         deltas = numpy.diff(timestamps[:-1])
         # The interval is not very accurate. We only check that the observed
         # interval is close on average.
-        assert numpy.average(deltas) == pytest.approx(dynamics_interval, abs=TIMING_TOLERANCE)
+        assert numpy.average(deltas) == pytest.approx(
+            dynamics_interval, abs=TIMING_TOLERANCE
+        )

--- a/python-libraries/nanover-openmm/tests_nanover_openmm/test_runner.py
+++ b/python-libraries/nanover-openmm/tests_nanover_openmm/test_runner.py
@@ -11,6 +11,7 @@ Tests for :mod:`nanover.openmm.runner`.
 import time
 import statistics
 import math
+import numpy
 
 import pytest
 
@@ -39,6 +40,8 @@ from .simulation_utils import (
     basic_simulation,
     serialized_simulation_path,
 )
+
+TIMING_TOLERANCE = 0.005  # 5ms
 
 
 class TestRunner:
@@ -476,7 +479,9 @@ class TestRunner:
         interval is a minimum (the MD engine may not be able to produce frames
         fast enough), also we accept some leeway.
         """
-        duration = 0.5
+        # We need at least a few frames to see intervals between
+        test_frames = 8
+
         dynamics_interval = 1 / fps
         client, runner = client_runner
         runner.dynamics_interval = dynamics_interval
@@ -487,14 +492,10 @@ class TestRunner:
         # only after that subscribe to the frames.
         runner.run(steps=frame_interval, block=True)
         client.subscribe_to_all_frames()
-
-        runner.run()
-        time.sleep(duration)
-        runner.cancel_run(wait=True)
+        runner.run(steps=test_frames * frame_interval, block=True)
 
         timestamps = [frame.server_timestamp for frame in client.frames]
-        deltas = [timestamps[i] - timestamps[i - 1] for i in range(1, len(timestamps))]
+        deltas = numpy.diff(timestamps[:-1])
         # The interval is not very accurate. We only check that the observed
-        # interval is greater than the expected one and we accept some
-        # deviation.
-        assert all(delta >= dynamics_interval * 0.90 for delta in deltas)
+        # interval is close on average.
+        assert numpy.average(deltas) == pytest.approx(dynamics_interval, abs=TIMING_TOLERANCE)


### PR DESCRIPTION
This has been way more confusing that it needed to be ever since I wrote it.

This is towards working out why these tests fail: https://github.com/IRL2/nanover-protocol/issues/116 (probably simply that `time.sleep` still isn't as reliable as the tests want) 