### PR TITLE
Restore lammps tests

### DIFF
--- a/python-libraries/nanover-lammps/src/nanover/lammps/LammpsImd.py
+++ b/python-libraries/nanover-lammps/src/nanover/lammps/LammpsImd.py
@@ -447,3 +447,9 @@ class LammpsImd:
         """
         if self.me == 0:
             logging.debug(passed_string, *args, **kwargs)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()

--- a/python-libraries/nanover-lammps/tests/test_lammps_converter.py
+++ b/python-libraries/nanover-lammps/tests/test_lammps_converter.py
@@ -6,14 +6,14 @@ from nanover.trajectory.frame_data import PARTICLE_POSITIONS, PARTICLE_ELEMENTS
 from nanover.trajectory import FrameData
 import sys
 
-pytestmark = pytest.mark.skipif(
-    sys.platform == "win32",
-    reason=(
-        "These tests can break the windows test runner on github. "
-        "This is tracked in issue #33: "
-        "<https://github.com/IRL2/nanover-protocol/issues/33>."
-    ),
-)
+# pytestmark = pytest.mark.skipif(
+#     sys.platform == "win32",
+#     reason=(
+#         "These tests can break the windows test runner on github. "
+#         "This is tracked in issue #33: "
+#         "<https://github.com/IRL2/nanover-protocol/issues/33>."
+#     ),
+# )
 
 
 @pytest.fixture

--- a/python-libraries/nanover-lammps/tests/test_lammps_converter.py
+++ b/python-libraries/nanover-lammps/tests/test_lammps_converter.py
@@ -6,15 +6,6 @@ from nanover.trajectory.frame_data import PARTICLE_POSITIONS, PARTICLE_ELEMENTS
 from nanover.trajectory import FrameData
 import sys
 
-# pytestmark = pytest.mark.skipif(
-#     sys.platform == "win32",
-#     reason=(
-#         "These tests can break the windows test runner on github. "
-#         "This is tracked in issue #33: "
-#         "<https://github.com/IRL2/nanover-protocol/issues/33>."
-#     ),
-# )
-
 
 @pytest.fixture
 def simple_atom_lammps_frame():

--- a/python-libraries/nanover-lammps/tests/test_lammps_converter.py
+++ b/python-libraries/nanover-lammps/tests/test_lammps_converter.py
@@ -25,9 +25,8 @@ def simple_atom_lammps_frame():
 
 @pytest.fixture
 def lammps_hook():
-    hook = LammpsImd()
-    yield hook
-    hook.close()
+    with LammpsImd() as hook:
+        yield hook
 
 
 def test_length_lammps_atoms(simple_atom_lammps_frame, lammps_hook):


### PR DESCRIPTION
Closes https://github.com/IRL2/nanover-protocol/issues/33 or at least attempts to make it a problem again.