### PR TITLE
Improve yield interval and testing

### DIFF
--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -43,16 +43,6 @@ def yield_interval(interval: float):
     return VariableIntervalGenerator(interval).yield_interval()
 
 
-def wait_sleep(seconds: float):
-    """
-    Do nothing for a period of time using time.sleep. Imprecise but doesn't use much CPU.
-    """
-    target = time.perf_counter() + seconds
-    duration = max(target - time.perf_counter(), 0)
-    if duration > 0:
-        time.sleep(duration)
-
-
 def wait_busy(seconds: float):
     """
     Do nothing for a period of time by tightly looping. Precise but uses much CPU.

--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -52,17 +52,15 @@ def wait_busy(seconds: float):
         pass
 
 
-def wait_mixed(seconds: float, sleep_error=0.01):
+def wait_mixed(seconds: float):
     """
-    Do nothing for a period of time by sleeping until close to the target then using CPU time.
+    Do nothing for a period of time by using a series of short sleeps.
     """
     target = time.perf_counter() + seconds
     while True:
         now = time.perf_counter()
         duration = max(target - now, 0)
-        if duration == 0:
-            return
-        elif duration > sleep_error:
+        if duration > 0:
             time.sleep(duration * 0.5)
         else:
-            time.sleep(0)
+            break

--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -40,12 +40,4 @@ def yield_interval(interval: float):
     :param interval: Number of seconds to ensure between yields
     :yield: Number of seconds since last yielding
     """
-    prev_yield = time.perf_counter()
-    yield 0
-    while True:
-        time_since_yield = time.perf_counter() - prev_yield
-        wait_duration = max(0.0, interval - time_since_yield)
-        time.sleep(wait_duration)
-        next_yield = time.perf_counter()
-        yield next_yield - prev_yield
-        prev_yield = next_yield
+    return VariableIntervalGenerator(interval).yield_interval()

--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -65,5 +65,4 @@ def wait_mixed(seconds: float, sleep_error=0.01):
         elif duration > sleep_error:
             time.sleep(duration * 0.5)
         else:
-            while time.perf_counter() < target:
-                pass
+            time.sleep(0)

--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -22,12 +22,12 @@ class VariableIntervalGenerator:
             self._interval = value
 
     def yield_interval(self):
-        prev_yield = time.perf_counter()
+        target = time.perf_counter()
+        prev_yield = target
         yield 0
         while True:
-            time_since_yield = time.perf_counter() - prev_yield
-            wait_duration = max(0.0, self.interval - time_since_yield)
-            time.sleep(wait_duration)
+            wait_mixed(target - time.perf_counter())
+            target += self.interval
             next_yield = time.perf_counter()
             yield next_yield - prev_yield
             prev_yield = next_yield
@@ -35,9 +35,46 @@ class VariableIntervalGenerator:
 
 def yield_interval(interval: float):
     """
-    Yield immediately and then every interval seconds, yielding the time in seconds that passed between yields.
+    Yield immediately and then roughly every interval seconds, yielding the time in seconds that passed between yields.
 
     :param interval: Number of seconds to ensure between yields
     :yield: Number of seconds since last yielding
     """
     return VariableIntervalGenerator(interval).yield_interval()
+
+
+def wait_sleep(seconds: float):
+    """
+    Do nothing for a period of time using time.sleep. Imprecise but doesn't use much CPU.
+    """
+    target = time.perf_counter() + seconds
+    duration = max(target - time.perf_counter(), 0)
+    if duration > 0:
+        time.sleep(duration)
+
+
+def wait_busy(seconds: float):
+    """
+    Do nothing for a period of time by tightly looping. Precise but uses much CPU.
+    """
+    target = time.perf_counter() + seconds
+    while time.perf_counter() < target:
+        pass
+
+
+def wait_mixed(seconds: float, sleep_error=.01):
+    """
+    Do nothing for a period of time by sleeping until close to the target then using CPU time.
+    """
+    target = time.perf_counter() + seconds
+    while True:
+        now = time.perf_counter()
+        duration = max(target - now, 0)
+        if duration == 0:
+            return
+        elif duration > sleep_error:
+            time.sleep(duration * .5)
+        else:
+            while time.perf_counter() < target:
+                pass
+

--- a/python-libraries/nanover-core/src/nanover/utilities/timing.py
+++ b/python-libraries/nanover-core/src/nanover/utilities/timing.py
@@ -26,8 +26,8 @@ class VariableIntervalGenerator:
         prev_yield = target
         yield 0
         while True:
-            wait_mixed(target - time.perf_counter())
             target += self.interval
+            wait_mixed(target - time.perf_counter())
             next_yield = time.perf_counter()
             yield next_yield - prev_yield
             prev_yield = next_yield
@@ -62,7 +62,7 @@ def wait_busy(seconds: float):
         pass
 
 
-def wait_mixed(seconds: float, sleep_error=.01):
+def wait_mixed(seconds: float, sleep_error=0.01):
     """
     Do nothing for a period of time by sleeping until close to the target then using CPU time.
     """
@@ -73,8 +73,7 @@ def wait_mixed(seconds: float, sleep_error=.01):
         if duration == 0:
             return
         elif duration > sleep_error:
-            time.sleep(duration * .5)
+            time.sleep(duration * 0.5)
         else:
             while time.perf_counter() < target:
                 pass
-

--- a/python-libraries/nanover-core/tests/utilities/test_timing.py
+++ b/python-libraries/nanover-core/tests/utilities/test_timing.py
@@ -6,7 +6,7 @@ import itertools
 
 from numpy import average
 
-from nanover.utilities.timing import yield_interval
+from nanover.utilities.timing import yield_interval, wait_busy
 
 TIMING_TOLERANCE = 0.005  # 5ms
 COMMON_INTERVALS = (1 / 10, 1 / 30, 1 / 60)
@@ -21,11 +21,11 @@ def test_yield_interval(interval, work_factor):
     """
 
     times = []
-    count = round(1 / interval)
+    count = 30
 
     for dt in itertools.islice(yield_interval(interval), count):
         times.append(time.perf_counter())
-        time.sleep(interval * work_factor)
+        wait_busy(interval * work_factor)
 
     intervals = numpy.diff(times)
     assert average(intervals) == pytest.approx(interval, abs=TIMING_TOLERANCE)
@@ -40,7 +40,7 @@ def test_yield_interval_dt(interval, work_factor):
 
     times = []
     reported_deltas = []
-    count = round(1 / interval)
+    count = 30
 
     times.append(time.perf_counter())
     for dt in itertools.islice(yield_interval(interval), count):


### PR DESCRIPTION
Change `yield_interval` so that intervals are measured from the attempted yield time not the actual yield time, so that errors do not compound over time. Also use a mixed strategy of sleeping until a certain threshold then busy-waiting for more accurate timing. 