### PR TITLE
Output sparse arrays of user forces and corresponding indices

### DIFF
--- a/examples/ase/nanover_nglview.ipynb
+++ b/examples/ase/nanover_nglview.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-06-06T16:04:25.392952Z",
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-06-06T16:04:26.572274Z",
@@ -68,11 +68,13 @@
     }
    },
    "outputs": [],
-   "source": "client = NGLClient.autoconnect()"
+   "source": [
+    "client = NGLClient.autoconnect()"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-06-06T16:04:27.291228Z",
@@ -96,22 +98,7 @@
      }
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c0180fd991194f70bf01989bd244b507",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "NGLWidget()"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "client.view"
    ]
@@ -146,7 +133,7 @@
   },
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -160,7 +147,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.7.6"
   },
   "pycharm": {
    "stem_cell": {
@@ -183,5 +170,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 2
 }

--- a/examples/ase/nanover_nglview.ipynb
+++ b/examples/ase/nanover_nglview.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-06-06T16:04:25.392952Z",
@@ -43,7 +43,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-06-06T16:04:26.572274Z",
@@ -68,13 +68,11 @@
     }
    },
    "outputs": [],
-   "source": [
-    "client = NGLClient.autoconnect()"
-   ]
+   "source": "client = NGLClient.autoconnect()"
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2019-06-06T16:04:27.291228Z",
@@ -98,7 +96,22 @@
      }
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "c0180fd991194f70bf01989bd244b507",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "NGLWidget()"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "client.view"
    ]
@@ -133,7 +146,7 @@
   },
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -147,7 +160,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.12.0"
   },
   "pycharm": {
    "stem_cell": {
@@ -170,5 +183,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
+++ b/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
@@ -299,7 +299,7 @@ class FrameData(metaclass=_FrameDataMeta):
         to_python=_n_by_3,
         to_raw=_flatten_array,
     )
-    sparse_user_index: float = _Shortcut(  # type: ignore[assignment]
+    sparse_user_index: List[float] = _Shortcut(  # type: ignore[assignment]
         key=SPARSE_USER_INDEX,
         record_type="arrays",
         field_type="float",

--- a/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
+++ b/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
@@ -50,6 +50,7 @@ _Shortcut = namedtuple(
 
 Array2Dfloat = Union[List[List[float]], npt.NDArray[Union[np.float32, np.float64]]]
 Array2Dint = Union[List[List[int]], npt.NDArray[Union[np.int_]]]
+Array1Dint = Union[List[int], npt.NDArray[np.int_]]
 
 
 class MissingDataError(KeyError):
@@ -299,12 +300,12 @@ class FrameData(metaclass=_FrameDataMeta):
         to_python=_n_by_3,
         to_raw=_flatten_array,
     )
-    sparse_user_index: List[float] = _Shortcut(  # type: ignore[assignment]
+    sparse_user_index: Array1Dint = _Shortcut(  # type: ignore[assignment]
         key=USER_FORCES_INDEX,
         record_type="arrays",
-        field_type="float",
-        to_python=_n_by_3,
-        to_raw=_flatten_array,
+        field_type="index",
+        to_python=_as_is,
+        to_raw=_as_is,
     )
 
     box_vectors: List[List[float]] = _Shortcut(  # type: ignore[assignment]

--- a/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
+++ b/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
@@ -38,8 +38,8 @@ POTENTIAL_ENERGY = "energy.potential"
 TOTAL_ENERGY = "energy.total"
 USER_ENERGY = "energy.user.total"
 
-SPARSE_USER_FORCES = "forces.user.sparse"
-SPARSE_USER_INDEX = "forces.user.index"
+USER_FORCES_SPARSE = "forces.user.sparse"
+USER_FORCES_INDEX = "forces.user.index"
 
 SERVER_TIMESTAMP = "server.timestamp"
 
@@ -293,14 +293,14 @@ class FrameData(metaclass=_FrameDataMeta):
         to_raw=_as_is,
     )
     sparse_user_forces: Array2Dfloat = _Shortcut(  # type: ignore[assignment]
-        key=SPARSE_USER_FORCES,
+        key=USER_FORCES_SPARSE,
         record_type="arrays",
         field_type="float",
         to_python=_n_by_3,
         to_raw=_flatten_array,
     )
     sparse_user_index: List[float] = _Shortcut(  # type: ignore[assignment]
-        key=SPARSE_USER_INDEX,
+        key=USER_FORCES_INDEX,
         record_type="arrays",
         field_type="float",
         to_python=_n_by_3,

--- a/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
+++ b/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
@@ -18,7 +18,6 @@ BOND_ORDERS = "bond.orders"
 PARTICLE_POSITIONS = "particle.positions"
 PARTICLE_VELOCITIES = "particle.velocities"
 PARTICLE_FORCES = "particle.forces"
-USER_FORCES = "forces.user"
 PARTICLE_ELEMENTS = "particle.elements"
 PARTICLE_NAMES = "particle.names"
 PARTICLE_RESIDUES = (
@@ -38,6 +37,9 @@ KINETIC_ENERGY = "energy.kinetic"
 POTENTIAL_ENERGY = "energy.potential"
 TOTAL_ENERGY = "energy.total"
 USER_ENERGY = "energy.user.total"
+
+SPARSE_USER_FORCES = "forces.user.sparse"
+SPARSE_USER_INDEX = "forces.user.index"
 
 SERVER_TIMESTAMP = "server.timestamp"
 
@@ -189,13 +191,6 @@ class FrameData(metaclass=_FrameDataMeta):
         to_python=_n_by_3,
         to_raw=_flatten_array,
     )
-    user_forces: Array2Dfloat = _Shortcut(  # type: ignore[assignment]
-        key=USER_FORCES,
-        record_type="arrays",
-        field_type="float",
-        to_python=_n_by_3,
-        to_raw=_flatten_array,
-    )
     particle_elements: List[int] = _Shortcut(  # type: ignore[assignment]
         key=PARTICLE_ELEMENTS,
         record_type="arrays",
@@ -296,6 +291,20 @@ class FrameData(metaclass=_FrameDataMeta):
         field_type="number_value",
         to_python=_as_is,
         to_raw=_as_is,
+    )
+    sparse_user_forces: Array2Dfloat = _Shortcut(  # type: ignore[assignment]
+        key=SPARSE_USER_FORCES,
+        record_type="arrays",
+        field_type="float",
+        to_python=_n_by_3,
+        to_raw=_flatten_array,
+    )
+    sparse_user_index: float = _Shortcut(  # type: ignore[assignment]
+        key=SPARSE_USER_INDEX,
+        record_type="arrays",
+        field_type="float",
+        to_python=_n_by_3,
+        to_raw=_flatten_array,
     )
 
     box_vectors: List[List[float]] = _Shortcut(  # type: ignore[assignment]

--- a/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
+++ b/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
@@ -18,6 +18,7 @@ BOND_ORDERS = "bond.orders"
 PARTICLE_POSITIONS = "particle.positions"
 PARTICLE_VELOCITIES = "particle.velocities"
 PARTICLE_FORCES = "particle.forces"
+USER_FORCES = "forces.user"
 PARTICLE_ELEMENTS = "particle.elements"
 PARTICLE_NAMES = "particle.names"
 PARTICLE_RESIDUES = (
@@ -183,6 +184,13 @@ class FrameData(metaclass=_FrameDataMeta):
     )
     particle_forces: Array2Dfloat = _Shortcut(  # type: ignore[assignment]
         key=PARTICLE_FORCES,
+        record_type="arrays",
+        field_type="float",
+        to_python=_n_by_3,
+        to_raw=_flatten_array,
+    )
+    user_forces: Array2Dfloat = _Shortcut(  # type: ignore[assignment]
+        key=USER_FORCES,
         record_type="arrays",
         field_type="float",
         to_python=_n_by_3,

--- a/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
+++ b/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
@@ -293,14 +293,14 @@ class FrameData(metaclass=_FrameDataMeta):
         to_python=_as_is,
         to_raw=_as_is,
     )
-    sparse_user_forces: Array2Dfloat = _Shortcut(  # type: ignore[assignment]
+    user_forces_sparse: Array2Dfloat = _Shortcut(  # type: ignore[assignment]
         key=USER_FORCES_SPARSE,
         record_type="arrays",
         field_type="float",
         to_python=_n_by_3,
         to_raw=_flatten_array,
     )
-    sparse_user_index: Array1Dint = _Shortcut(  # type: ignore[assignment]
+    user_forces_index: Array1Dint = _Shortcut(  # type: ignore[assignment]
         key=USER_FORCES_INDEX,
         record_type="arrays",
         field_type="index",

--- a/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
@@ -364,11 +364,22 @@ def get_imd_forces_from_system(system: app.Simulation) -> List[mm.CustomExternal
     ]
 
 
-def get_sparse_forces(forces: npt.NDArray) -> Tuple[npt.NDArray, npt.NDArray]:
-    sparse_indices = np.unique(np.nonzero(forces)[0])
+def get_sparse_forces(user_forces: npt.NDArray) -> Tuple[npt.NDArray, npt.NDArray]:
+    """
+    Takes in an array of user forces acting on the system containing N particles
+    and outputs two arrays that describe these user forces in a sparse form:
+
+    - The first contains the indices of the particles for which the user forces
+      are non-zero
+    - The second contains the non-zero user forces associated with each index
+
+    :param user_forces: Array of user forces with dimensions (N, 3)
+    :return: Array of particle indices, Array of corresponding user forces
+    """
+    sparse_indices = np.unique(np.nonzero(user_forces)[0])
     sparse_forces = np.zeros((sparse_indices.shape[0], 3))
 
     for index in range(sparse_indices.shape[0]):
-        sparse_forces[index, :] = forces[sparse_indices[index]]
+        sparse_forces[index, :] = user_forces[sparse_indices[index]]
 
     return sparse_indices, sparse_forces

--- a/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
@@ -114,7 +114,7 @@ class NanoverImdReporter:
         self._previous_force_index: Set[int] = set()
         self._frame_index = 0
         self._total_user_energy = 0.0
-        self._user_forces: Optional[npt.NDArray] = None
+        self._user_forces: npt.NDArray = np.empty(0)
 
         self._did_first_frame = False
         self._simulation_counter = simulation_counter

--- a/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
@@ -114,7 +114,7 @@ class NanoverImdReporter:
         self._previous_force_index: Set[int] = set()
         self._frame_index = 0
         self._total_user_energy = 0.0
-        self._user_forces = None
+        self._user_forces: Optional[npt.NDArray] = None
 
         self._did_first_frame = False
         self._simulation_counter = simulation_counter

--- a/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
@@ -114,7 +114,7 @@ class NanoverImdReporter:
         self._previous_force_index: Set[int] = set()
         self._frame_index = 0
         self._total_user_energy = 0.0
-        self._user_forces = np.zeros(self.positions)
+        self._user_forces = None
 
         self._did_first_frame = False
         self._simulation_counter = simulation_counter

--- a/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
@@ -368,7 +368,7 @@ def get_sparse_forces(forces: npt.NDArray) -> Tuple[npt.NDArray, npt.NDArray]:
     sparse_indices = np.unique(np.nonzero(forces)[0])
     sparse_forces = np.zeros((sparse_indices.shape[0], 3))
 
-    for index in sparse_indices:
-        sparse_forces[index, :] = forces[index]
+    for index in range(sparse_indices.shape[0]):
+        sparse_forces[index, :] = forces[sparse_indices[index]]
 
     return sparse_indices, sparse_forces

--- a/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
@@ -173,8 +173,8 @@ class NanoverImdReporter:
                 frame_data.particle_positions = positions
                 frame_data.user_energy = self._total_user_energy
                 sparse_indices, sparse_forces = get_sparse_forces(self._user_forces)
-                frame_data.sparse_user_forces = sparse_forces
-                frame_data.sparse_user_index = sparse_indices
+                frame_data.user_forces_sparse = sparse_forces
+                frame_data.user_forces_index = sparse_indices
                 self.frame_publisher.send_frame(self._frame_index, frame_data)
                 self._frame_index += 1
 

--- a/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/imd.py
@@ -372,4 +372,3 @@ def get_sparse_forces(forces: npt.NDArray) -> Tuple[npt.NDArray, npt.NDArray]:
         sparse_forces[index, :] = forces[index]
 
     return sparse_indices, sparse_forces
-

--- a/python-libraries/nanover-openmm/tests_nanover_openmm/test_imd.py
+++ b/python-libraries/nanover-openmm/tests_nanover_openmm/test_imd.py
@@ -61,6 +61,20 @@ def app_simulation_and_reporter_with_interactions(app_simulation_and_reporter):
     return app, simulation, reporter
 
 
+@pytest.fixture
+def app_simulation_and_reporter_with_constant_force_interactions(app_simulation_and_reporter):
+    app, simulation, reporter = app_simulation_and_reporter
+    app.imd.insert_interaction(
+        "interaction.0",
+        ParticleInteraction(
+            position=(0.0, 0.0, 1.0),
+            particles=(0, 4),
+            interaction_type="constant",
+        ),
+    )
+    return app, simulation, reporter
+
+
 def test_create_imd_force(empty_imd_force):
     """
     The force created has the expected parameters per particle.
@@ -221,6 +235,25 @@ class TestNanoverImdReporter:
         assert len(frame.user_forces_sparse) >= 1
         assert len(frame.user_forces_sparse) == len(frame.user_forces_index)
         assert np.all(frame.user_forces_sparse) != 0.0
+
+    def test_sparse_user_forces_elements(self, app_simulation_and_reporter_with_constant_force_interactions):
+        """
+        Test that the values of the sparse user forces are approximately as expected from the initial
+        positions and the position from which the user force is applied, for a constant force acting
+        on the C atoms.
+        """
+        app, simulation, reporter = app_simulation_and_reporter_with_constant_force_interactions
+        request_id = app.frame_publisher._get_new_request_id()
+        frame_queues = app.frame_publisher.frame_queues
+        with frame_queues.one_queue(request_id, Queue) as publisher_queue:
+            simulation.step(10)
+            frames = list(publisher_queue.queue)
+        frame = FrameData(frames[2].frame)
+        # For a mass-weighted constant force applied at [0.0, 0.0, 1.0] to the COM of the C atoms
+        mass_weighted_user_forces_t0 = [[0.0, 0.0, -6.0], [0.0, 0.0, -6.0]]
+        assert set(frame.user_forces_index) == {0, 4}
+        for i in range(len(frame.user_forces_index)):
+            assert frame.user_forces_sparse[i] == pytest.approx(mass_weighted_user_forces_t0[i], abs=2e-3)
 
     @pytest.mark.parametrize("interval", (1, 2, 3, 4))
     def test_send_frame_frequency(self, app_simulation_and_reporter, interval):

--- a/python-libraries/nanover-openmm/tests_nanover_openmm/test_imd.py
+++ b/python-libraries/nanover-openmm/tests_nanover_openmm/test_imd.py
@@ -201,7 +201,7 @@ class TestNanoverImdReporter:
         # frame 2: forces from frame 1?
         frame = FrameData(frames[2].frame)
 
-        assert set(frame.sparse_user_index) == {0, 1, 4, 5}
+        assert set(frame.user_forces_index) == {0, 1, 4, 5}
 
     @pytest.mark.parametrize("interval", (1, 2, 3, 4))
     def test_send_frame_frequency(self, app_simulation_and_reporter, interval):

--- a/python-libraries/nanover-openmm/tests_nanover_openmm/test_imd.py
+++ b/python-libraries/nanover-openmm/tests_nanover_openmm/test_imd.py
@@ -62,7 +62,9 @@ def app_simulation_and_reporter_with_interactions(app_simulation_and_reporter):
 
 
 @pytest.fixture
-def app_simulation_and_reporter_with_constant_force_interactions(app_simulation_and_reporter):
+def app_simulation_and_reporter_with_constant_force_interactions(
+    app_simulation_and_reporter,
+):
     app, simulation, reporter = app_simulation_and_reporter
     app.imd.insert_interaction(
         "interaction.0",
@@ -236,13 +238,17 @@ class TestNanoverImdReporter:
         assert len(frame.user_forces_sparse) == len(frame.user_forces_index)
         assert np.all(frame.user_forces_sparse) != 0.0
 
-    def test_sparse_user_forces_elements(self, app_simulation_and_reporter_with_constant_force_interactions):
+    def test_sparse_user_forces_elements(
+        self, app_simulation_and_reporter_with_constant_force_interactions
+    ):
         """
         Test that the values of the sparse user forces are approximately as expected from the initial
         positions and the position from which the user force is applied, for a constant force acting
         on the C atoms.
         """
-        app, simulation, reporter = app_simulation_and_reporter_with_constant_force_interactions
+        app, simulation, reporter = (
+            app_simulation_and_reporter_with_constant_force_interactions
+        )
         request_id = app.frame_publisher._get_new_request_id()
         frame_queues = app.frame_publisher.frame_queues
         with frame_queues.one_queue(request_id, Queue) as publisher_queue:
@@ -253,7 +259,9 @@ class TestNanoverImdReporter:
         mass_weighted_user_forces_t0 = [[0.0, 0.0, -6.0], [0.0, 0.0, -6.0]]
         assert set(frame.user_forces_index) == {0, 4}
         for i in range(len(frame.user_forces_index)):
-            assert frame.user_forces_sparse[i] == pytest.approx(mass_weighted_user_forces_t0[i], abs=2e-3)
+            assert frame.user_forces_sparse[i] == pytest.approx(
+                mass_weighted_user_forces_t0[i], abs=2e-3
+            )
 
     @pytest.mark.parametrize("interval", (1, 2, 3, 4))
     def test_send_frame_frequency(self, app_simulation_and_reporter, interval):

--- a/python-libraries/nanover-openmm/tests_nanover_openmm/test_imd.py
+++ b/python-libraries/nanover-openmm/tests_nanover_openmm/test_imd.py
@@ -203,6 +203,25 @@ class TestNanoverImdReporter:
 
         assert set(frame.user_forces_index) == {0, 1, 4, 5}
 
+    def test_sparse_user_forces(self, app_simulation_and_reporter_with_interactions):
+        """
+        Test that the sparse user forces exist in the frame data when a user applies an iMD force,
+        check that the size of the array of forces is equal to the size of the array of corresponding
+        indices, and check that none of the elements of the sparse forces array are zero.
+        """
+        app, simulation, reporter = app_simulation_and_reporter_with_interactions
+        request_id = app.frame_publisher._get_new_request_id()
+        frame_queues = app.frame_publisher.frame_queues
+        with frame_queues.one_queue(request_id, Queue) as publisher_queue:
+            simulation.step(10)
+            frames = list(publisher_queue.queue)
+        frame = FrameData(frames[2].frame)
+        assert frame.user_forces_sparse
+        assert frame.user_forces_index
+        assert len(frame.user_forces_sparse) >= 1
+        assert len(frame.user_forces_sparse) == len(frame.user_forces_index)
+        assert np.all(frame.user_forces_sparse) != 0.0
+
     @pytest.mark.parametrize("interval", (1, 2, 3, 4))
     def test_send_frame_frequency(self, app_simulation_and_reporter, interval):
         """


### PR DESCRIPTION
This is a PR to add sparse arrays of user forces and indices to the output of NanoVer simulations. The user forces and indices are labelled the same way in FrameData as they are in the Rust server. This means that they should also be readable by the mdanalysis functions that already exist to parse sparse user forces into full arrays of user forces (python server recording functionality required to test this).