### PR TITLE
non-reporter omm

### DIFF
--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -3,14 +3,17 @@ from pathlib import Path
 from typing import Optional, Any
 
 from openmm.app import Simulation, StateDataReporter
+from openmm.unit import kilojoule_per_mole
 
 from nanover.app import NanoverImdApplication
-from nanover.openmm import serializer
+from nanover.openmm import serializer, openmm_to_frame_data
 from nanover.openmm.imd import (
     create_imd_force,
     NanoverImdReporter,
-    add_imd_force_to_system,
+    add_imd_force_to_system, ImdForceManager, OTHER_FORCE_GROUP_MASK,
 )
+from nanover.protocol.state import State
+from nanover.trajectory.frame_data import Array2Dfloat
 
 
 class OpenMMSimulation:
@@ -49,6 +52,9 @@ class OpenMMSimulation:
         self.reporter: Optional[NanoverImdReporter] = None
         self.verbose_reporter: Optional[StateDataReporter] = None
 
+        self.frame_index = 0
+        self.imd_force_manager: Optional[ImdForceManager] = None
+
     def load(self):
         if self.xml_path is None or self.simulation is not None:
             return
@@ -68,31 +74,76 @@ class OpenMMSimulation:
         self.simulation.context.loadCheckpoint(self.checkpoint)
 
         try:
-            self.simulation.reporters.remove(self.reporter)
             if self.verbose_reporter is not None:
                 self.simulation.reporters.remove(self.verbose_reporter)
         except ValueError:
             pass
 
-        self.reporter = NanoverImdReporter(
-            frame_interval=self.frame_interval,
-            force_interval=self.force_interval,
-            include_velocities=self.include_velocities,
-            include_forces=self.include_forces,
-            imd_force=self.imd_force,
-            imd_state=self.app_server.imd,
-            frame_publisher=self.app_server.frame_publisher,
-        )
-        self.simulation.reporters.append(self.reporter)
         if self.verbose_reporter is not None:
             self.simulation.reporters.append(self.verbose_reporter)
 
-    def advance_to_next_report(self):
-        assert self.simulation is not None
-        self.simulation.step(self.frame_interval)
+        self.imd_force_manager = ImdForceManager(self.app_server.imd, self.imd_force)
+
+        self.app_server.frame_publisher.send_frame(0, self.make_topology_frame(self.simulation))
+        self.frame_index = 1
 
     def advance_by_seconds(self, dt: float):
         self.advance_to_next_report()
 
     def advance_by_one_step(self):
         self.advance_to_next_report()
+
+    def advance_to_next_report(self):
+        assert self.simulation is not None
+        self.simulation.step(self.frame_interval)
+
+        step = self.simulation.currentStep
+        state = self.simulation.context.getState(
+            getPositions=True,
+            getForces=self.include_forces,
+            getVelocities=self.include_velocities,
+            getEnergy=True,
+        )
+
+        do_frame = step % self.frame_interval == 0
+        do_imd = step % self.force_interval == 0
+
+        positions = state.getPositions(asNumpy=True)
+        if do_frame:
+            frame_data = self.make_regular_frame(self.simulation, state, positions)
+            self.app_server.frame_publisher.send_frame(self.frame_index, frame_data)
+            self.frame_index += 1
+        if do_imd:
+            self.imd_force_manager.update_interactions(self.simulation, positions)
+
+    def make_topology_frame(self, simulation: Simulation):
+        state = simulation.context.getState(getPositions=True, getEnergy=True)
+        topology = simulation.topology
+        frame_data = openmm_to_frame_data(state=state, topology=topology)
+        return frame_data
+
+    def make_regular_frame(
+        self,
+        simulation: Simulation,
+        state: State,
+        positions: Array2Dfloat,
+    ):
+        frame_data = openmm_to_frame_data(
+            state=state,
+            topology=None,
+            include_positions=False,
+            include_velocities=self.include_velocities,
+            include_forces=self.include_forces,
+        )
+        frame_data.particle_positions = positions
+        self.imd_force_manager.add_to_frame_data(frame_data)
+
+        # Get the simulation state excluding the IMD force, and recalculate potential energy without it:
+        energy_no_imd = (
+            simulation.context.getState(getEnergy=True, groups=OTHER_FORCE_GROUP_MASK)
+            .getPotentialEnergy()
+            .value_in_unit(kilojoule_per_mole)
+        )
+        frame_data.potential_energy = energy_no_imd
+
+        return frame_data

--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -117,12 +117,12 @@ class OpenMMSimulation:
         do_imd = step % self.force_interval == 0
 
         positions = state.getPositions(asNumpy=True)
+        if do_imd:
+            self.imd_force_manager.update_interactions(self.simulation, positions)
         if do_frame:
             frame_data = self.make_regular_frame(self.simulation, state, positions)
             self.app_server.frame_publisher.send_frame(self.frame_index, frame_data)
             self.frame_index += 1
-        if do_imd:
-            self.imd_force_manager.update_interactions(self.simulation, positions)
 
     def make_topology_frame(self, simulation: Simulation):
         assert self.simulation is not None

--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -9,7 +9,6 @@ from nanover.app import NanoverImdApplication
 from nanover.openmm import serializer, openmm_to_frame_data
 from nanover.openmm.imd import (
     create_imd_force,
-    NanoverImdReporter,
     add_imd_force_to_system,
     ImdForceManager,
     OTHER_FORCE_GROUP_MASK,
@@ -65,7 +64,6 @@ class OpenMMSimulation:
         self.imd_force = create_imd_force()
         self.simulation: Optional[Simulation] = None
         self.checkpoint: Optional[Any] = None
-        self.reporter: Optional[NanoverImdReporter] = None
         self.verbose_reporter: Optional[StateDataReporter] = None
 
         self.frame_index = 0

--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -98,7 +98,11 @@ class OpenMMSimulation:
         self.advance_to_next_report()
 
     def advance_to_next_report(self):
-        assert self.simulation is not None and self.imd_force_manager is not None and self.app_server is not None
+        assert (
+            self.simulation is not None
+            and self.imd_force_manager is not None
+            and self.app_server is not None
+        )
         self.simulation.step(self.frame_interval)
 
         step = self.simulation.currentStep

--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -10,7 +10,9 @@ from nanover.openmm import serializer, openmm_to_frame_data
 from nanover.openmm.imd import (
     create_imd_force,
     NanoverImdReporter,
-    add_imd_force_to_system, ImdForceManager, OTHER_FORCE_GROUP_MASK,
+    add_imd_force_to_system,
+    ImdForceManager,
+    OTHER_FORCE_GROUP_MASK,
 )
 from nanover.protocol.state import State
 from nanover.trajectory.frame_data import Array2Dfloat
@@ -84,7 +86,9 @@ class OpenMMSimulation:
 
         self.imd_force_manager = ImdForceManager(self.app_server.imd, self.imd_force)
 
-        self.app_server.frame_publisher.send_frame(0, self.make_topology_frame(self.simulation))
+        self.app_server.frame_publisher.send_frame(
+            0, self.make_topology_frame(self.simulation)
+        )
         self.frame_index = 1
 
     def advance_by_seconds(self, dt: float):

--- a/python-libraries/nanover-omni/src/nanover/omni/openmm.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/openmm.py
@@ -98,7 +98,7 @@ class OpenMMSimulation:
         self.advance_to_next_report()
 
     def advance_to_next_report(self):
-        assert self.simulation is not None
+        assert self.simulation is not None and self.imd_force_manager is not None and self.app_server is not None
         self.simulation.step(self.frame_interval)
 
         step = self.simulation.currentStep
@@ -121,6 +121,8 @@ class OpenMMSimulation:
             self.imd_force_manager.update_interactions(self.simulation, positions)
 
     def make_topology_frame(self, simulation: Simulation):
+        assert self.simulation is not None
+
         state = simulation.context.getState(getPositions=True, getEnergy=True)
         topology = simulation.topology
         frame_data = openmm_to_frame_data(state=state, topology=topology)
@@ -132,6 +134,8 @@ class OpenMMSimulation:
         state: State,
         positions: Array2Dfloat,
     ):
+        assert self.simulation is not None and self.imd_force_manager is not None
+
         frame_data = openmm_to_frame_data(
             state=state,
             topology=None,


### PR DESCRIPTION
Switches to fetching OMM state directly for the purposes of generating and sending frames. This is equivalent to how the rust server does things, and also corrects and ordering error that was synchronising how forces, energies, and velocities were being reported. Drops the spurious capability to update IMD forces independently of frame updates. Adds docstrings and comments for Omni's `OpenMMSimulation`.