### PR TITLE
Remove total energy field from FrameData for OpenMM

### DIFF
--- a/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
+++ b/python-libraries/nanover-core/src/nanover/trajectory/frame_data.py
@@ -35,7 +35,6 @@ CHAIN_COUNT = "chain.count"
 
 KINETIC_ENERGY = "energy.kinetic"
 POTENTIAL_ENERGY = "energy.potential"
-TOTAL_ENERGY = "energy.total"
 USER_ENERGY = "energy.user.total"
 
 USER_FORCES_SPARSE = "forces.user.sparse"
@@ -274,13 +273,6 @@ class FrameData(metaclass=_FrameDataMeta):
     )
     potential_energy: float = _Shortcut(  # type: ignore[assignment]
         key=POTENTIAL_ENERGY,
-        record_type="values",
-        field_type="number_value",
-        to_python=_as_is,
-        to_raw=_as_is,
-    )
-    total_energy: float = _Shortcut(  # type: ignore[assignment]
-        key=TOTAL_ENERGY,
         record_type="values",
         field_type="number_value",
         to_python=_as_is,

--- a/python-libraries/nanover-openmm/src/nanover/openmm/converter.py
+++ b/python-libraries/nanover-openmm/src/nanover/openmm/converter.py
@@ -27,9 +27,7 @@ def add_openmm_state_to_frame_data(
     :param include_positions: If ``True``, the particle positions are read from
         the state and included in the frame.
     :param include_energies: If ``True``, the kinetic and potential energies
-        are read from the state, the total energy is calculated as the sum of
-        these energies, and the kinetic, potential and total energies are
-        included in the frame.
+        are read from the state and included in the frame.
     :param include_velocities: If ``True``, the particle velocities are read
         from the state and included in the frame.
     :param include_forces: If ``True``, the particle forces are read from the
@@ -44,10 +42,8 @@ def add_openmm_state_to_frame_data(
     if include_energies:
         potential_energy = state.getPotentialEnergy().value_in_unit(kilojoule_per_mole)
         kinetic_energy = state.getKineticEnergy().value_in_unit(kilojoule_per_mole)
-        total_energy = potential_energy + kinetic_energy
         data.kinetic_energy = kinetic_energy
         data.potential_energy = potential_energy
-        data.total_energy = total_energy
     if include_velocities:
         velocities = state.getVelocities(asNumpy=True)
         data.particle_velocities = velocities
@@ -120,9 +116,7 @@ def openmm_to_frame_data(
     :param include_positions: If ``True``, the particle positions are read from
         the state and included in the frame.
     :param include_energies: If ``True``, the kinetic and potential energies
-        are read from the state, the total energy is calculated as the sum of
-        these energies, and the kinetic, potential and total energies are
-        included in the frame.
+        are read from the state and included in the frame.
     :param include_velocities: If ``True``, the particle velocities are read
         from the state and included in the frame.
     :param include_forces: If ``True``, the particle forces are read from the


### PR DESCRIPTION
This PR removes the "total" energy from the FrameData. The quantity that was previously being calculated was the sum of the kinetic and potential (system only, no user energy) energies. This is not a quantity that OpenMM calculates, and given that we deliver the kinetic, potential and user energies separately, it is probably more transparent to remove this field and allow a user to calculate the total energy themselves, at which point they can be clear about whether or not they are including the user energy in their calculation.