### PR TITLE
Fix MDAnalysis force units when loading NanoVer trajectory as an MDAnalysis Universe

### DIFF
--- a/python-libraries/nanover-mdanalysis/src/nanover/mdanalysis/universe.py
+++ b/python-libraries/nanover-mdanalysis/src/nanover/mdanalysis/universe.py
@@ -247,7 +247,7 @@ class NanoverReader(ProtoReader):
     def _add_user_forces_to_ts(self, frame, ts):
         """
         Read the user forces from the frame if they are available and
-        converts them to the correct units.
+        converts them to the units used by MDAnalysis if required.
         """
         try:
             indices = frame.arrays["forces.user.index"]


### PR DESCRIPTION
This PR aims to fix Issue #227, converting the units of force used by NanoVer (i.e. kJ/(mol.nm)) to the units of force used by MDAnalysis (i.e. kJ/(mol.Angstrom)) for the user forces and system forces when loading a recorded NanoVer trajectory as an MDAnalysis universe.