### PR TITLE
Update description of `OpenMMSimulation` class

### DIFF
--- a/examples/openmm/openmm_polyalanine.ipynb
+++ b/examples/openmm/openmm_polyalanine.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "## Running the simulation with NanoVer\n",
     "\n",
-    "NanoVer works using a client-server architecture. A NanoVer runner creates the server and makes a link between that server and the simulation. Here, we create an `OmniRunner` and pass an `OpenMMSimulation` to it. The `OpenMMSimulation` class is responsible for delivering data output by the OpenMM simulation to the client. An `OpenMMSimulation` delivers data in a similar way to a reporter: the data is delivered in frames, which are published at intervals of simulation steps specified by the `frame_interval` property (defaults to 5 steps)."
+    "NanoVer works using a client-server architecture. A NanoVer runner creates the server and makes a link between that server and the simulation. Here, we create an `OmniRunner` and pass an `OpenMMSimulation` to it. The `OpenMMSimulation` class is responsible for delivering data output by the OpenMM simulation to the client. An `OpenMMSimulation` delivers data in a similar way to a reporter in OpenMM: the data is delivered in frames, which are published at intervals of simulation steps specified by the `frame_interval` property (defaults to 5 steps)."
    ]
   },
   {

--- a/examples/openmm/openmm_polyalanine.ipynb
+++ b/examples/openmm/openmm_polyalanine.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "## Running the simulation with NanoVer\n",
     "\n",
-    "NanoVer works using a client-server architecture. A NanoVer runner creates the server and make the link between that server and the simulation. Here, we create an `OmniRunner` and pass an `OpenMMSimulation` to it. Note that the `OpenMMSimulation` class automatically adds a `NanoverIMDReporter` to the simulation (which enables NanoVer to extract data from the simulation as it runs)."
+    "NanoVer works using a client-server architecture. A NanoVer runner creates the server and makes a link between that server and the simulation. Here, we create an `OmniRunner` and pass an `OpenMMSimulation` to it. The `OpenMMSimulation` class is responsible for delivering data output by the OpenMM simulation to the client. An `OpenMMSimulation` delivers data in a similar way to a reporter: the data is delivered in frames, which are published at intervals of simulation steps specified by the `frame_interval` property (defaults to 5 steps)."
    ]
   },
   {


### PR DESCRIPTION
This PR aims to fix Issue #224 by updating the description of the `OpenMMSimulation` class in the polyalanine notebook, in light of the new non-reporter style functionality for running OpenMM simulations via NanoVer.