### PR TITLE
Fix DCD reporter section of example notebook

### DIFF
--- a/examples/openmm/openmm_polyalanine.ipynb
+++ b/examples/openmm/openmm_polyalanine.ipynb
@@ -239,7 +239,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Saving the trajectory can be done in the regular way for OpenMM simulations: by attaching a reporter. Here we attach a DCD reporter to save the trajectory in the DCD format every 500 frames."
+    "Saving the trajectory can be done in the regular way for OpenMM simulations: by attaching a reporter. Here we attach a DCD reporter to save the trajectory in the DCD format every 500 frames.\n",
+    "\n",
+    "**Note**: It is essential to load the simulation _before_ attaching a DCD reporter, using the `.load()` function."
    ]
   },
   {
@@ -248,6 +250,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Load the simulation\n",
+    "polyalanine_simulation.load()\n",
+    "\n",
     "# Attach the DCD reporter\n",
     "dcd_reporter = app.DCDReporter('output.dcd', 500)\n",
     "polyalanine_simulation.simulation.reporters.append(dcd_reporter)\n",


### PR DESCRIPTION
As @ludovicaisa noticed, if you run only the functionality required to record a NanoVer trajectory using a DCD reporter as described by the `openmm_polyalanine` notebook, it is not possible to attach a DCD reporter to an OpenMMSimulation without first loading it using the `.load()` function. This PR adds a note to the notebook to specify this, and adds a line of code to do this. This addresses Issue #239.