### PR TITLE
Skip LAMMPS tests on windows due to crashes, lengthen ESSD service removal time, run LAMMPS tests on dynamic port

### DIFF
--- a/python-libraries/nanover-essd/tests/test_essd_client_server.py
+++ b/python-libraries/nanover-essd/tests/test_essd_client_server.py
@@ -72,7 +72,7 @@ def test_remove_service(client_server, service):
     )
     assert service in services
     server.unregister_service(service)
-    time.sleep(TEST_INTERVAL_TIME)
+    time.sleep(TEST_SEARCH_TIME)
     services = set(
         client.search_for_services(
             search_time=TEST_SEARCH_TIME, interval=TEST_INTERVAL_TIME

--- a/python-libraries/nanover-lammps/tests/test_lammps_converter.py
+++ b/python-libraries/nanover-lammps/tests/test_lammps_converter.py
@@ -8,12 +8,12 @@ import sys
 
 
 pytestmark = pytest.mark.skipif(
-     sys.platform == "win32",
-     reason=(
-         "These tests can break the windows test runner on github. "
-         "This is tracked in issue #33: "
-         "<https://github.com/IRL2/nanover-protocol/issues/33>."
-     ),
+    sys.platform == "win32",
+    reason=(
+        "These tests can break the windows test runner on github. "
+        "This is tracked in issue #33: "
+        "<https://github.com/IRL2/nanover-protocol/issues/33>."
+    ),
 )
 
 

--- a/python-libraries/nanover-lammps/tests/test_lammps_converter.py
+++ b/python-libraries/nanover-lammps/tests/test_lammps_converter.py
@@ -7,6 +7,16 @@ from nanover.trajectory import FrameData
 import sys
 
 
+pytestmark = pytest.mark.skipif(
+     sys.platform == "win32",
+     reason=(
+         "These tests can break the windows test runner on github. "
+         "This is tracked in issue #33: "
+         "<https://github.com/IRL2/nanover-protocol/issues/33>."
+     ),
+)
+
+
 @pytest.fixture
 def simple_atom_lammps_frame():
     mock = MockLammps()

--- a/python-libraries/nanover-lammps/tests/test_lammps_converter.py
+++ b/python-libraries/nanover-lammps/tests/test_lammps_converter.py
@@ -26,7 +26,7 @@ def simple_atom_lammps_frame():
 
 @pytest.fixture
 def lammps_hook():
-    with LammpsImd() as hook:
+    with LammpsImd(port=0) as hook:
         yield hook
 
 


### PR DESCRIPTION
As seen in https://github.com/IRL2/nanover-protocol/issues/33