### PR TITLE
Revert "Don't use old grpcio-tools"

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Test that the repo is sane and does not contain superfluous __init__ file
         run: bash ./maintainers/check_extra_init_files.sh
       - name: Install dependencies
-        run: conda install -y python conda-build grpcio-tools conda-verify
+        run: conda install -y python conda-build "grpcio-tools<1.62" conda-verify
       - name: Compiling the prototypes
         run: python ./python-libraries/compile_proto.py --proto-dir=./protocol --python-dir=./python-libraries/nanover-core/src
       - name: Building the Conda packages


### PR DESCRIPTION
Reverts IRL2/nanover-protocol#252

Seems to cause issues that aren't caught by the tests