### PR TITLE
Specify conda dependencies at environment creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,8 @@ page in our documentation for detailed instructions on installing NanoVer.
 * Install Anaconda
 * Clone the nanover-protocol repository
 * In a terminal, in the repository root:
-    * Create a conda environment (here we call the environment "nanover-dev"): `conda create -n nanover-dev "python>3.11"`
+    * Create a conda environment (here we call the environment "nanover-dev") with the required depencies: `conda create -n nanover-dev -c conda-forge "python>3.11" openmm MDAnalysis MDAnalysisTests ase mpi4py`
     * Activate the conda environment: `conda activate nanover-dev`
-    * Install the required conda package: `conda install -c conda-forge openmm MDAnalysis MDAnalysisTests ase mpi4py`
     * Compile the protocol and install the NanoVer python libraries in your conda environment: `./compile.sh --no-dotnet`.  If you do not plan on modifying the python packages, you may run `./compile.sh --no-edit --no-dotnet` instead. Otherwise, by default, the NanoVer packages will be installed in edit mode (`pip install -e`) meaning that changes in the `nanover-protocol` directory will be directly reflected in your python environment.
 
 Here, we installed only the python library. Using the `--no-dotnet` argument, we skipped building the C# libraries for NanoVer. Would you want to work on these library, you would need to:


### PR DESCRIPTION
This way conda can pick the appropriate python version e.g openmm doesn't necessarily support the latest.