### PR TITLE
Update the ASE notebooks that use the `ASESimulation` class

### DIFF
--- a/examples/ase/ase_basic_example.ipynb
+++ b/examples/ase/ase_basic_example.ipynb
@@ -11,8 +11,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook walks through setting up a simulation with ASE and combining it with NanoVer to make an interactive molecular dynamics simulation. \n",
-    "We then connect to the simulation from a client, so we can look at the data being produced and visualize it."
+    "This notebook demonstrates how to set up a molecular simulation with ASE and combine it with NanoVer to run an interactive molecular dynamics (iMD) simulation. \n",
+    "We then connect to the simulation from a client, so we can look at the data being produced and visualize it.\n",
+    "\n",
+    "\n",
+    "**Note**: This example demonstrates running iMD simulations using ASE via NanoVer. For tutorials that demonstrate the different ways to interface ASE with OpenMM via NanoVer, check out the tutorials in this directory prefixed with `ase_openmm`."
    ]
   },
   {
@@ -31,30 +34,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:07.749267Z",
+     "start_time": "2024-10-22T14:18:07.638160Z"
     }
    },
-   "outputs": [],
    "source": [
     "from ase import units\n",
     "from ase.calculators.emt import EMT\n",
     "from ase.lattice.cubic import FaceCenteredCubic\n",
     "from ase.md import Langevin\n",
     "from ase.md.velocitydistribution import MaxwellBoltzmannDistribution"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 1
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:07.754630Z",
+     "start_time": "2024-10-22T14:18:07.751558Z"
     }
    },
-   "outputs": [],
    "source": [
     "size = 2\n",
     "# Set up a crystal\n",
@@ -65,44 +74,55 @@
     "# Describe the interatomic interactions with Effective Medium Theory\n",
     "atoms.calc = EMT()\n",
     "# Set the atomic momenta to 300 Kelvin. \n",
-    "MaxwellBoltzmannDistribution(atoms, temperature_K=300 * units.kB)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Set up our molecular dynamics simulation, we'll run Langevin dynamics at room temperature"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {
-    "pycharm": {
-     "is_executing": false
-    }
-   },
+    "MaxwellBoltzmannDistribution(atoms, temperature_K=300)"
+   ],
    "outputs": [],
-   "source": [
-    "dyn = Langevin(atoms, timestep=1 * units.fs, temperature_K=300 * units.kB, friction=0.5)"
-   ]
+   "execution_count": 2
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "Next we need to define the component of the molecular dynamics simulation that performs the numerical integration of the equations of motion. We're going to run Langevin dynamics at room temperature:"
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "pycharm": {
+     "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:09.633559Z",
+     "start_time": "2024-10-22T14:18:09.630717Z"
+    }
+   },
+   "source": "dyn = Langevin(atoms, timestep=1 * units.fs, temperature_K=300, friction=0.5)",
+   "outputs": [],
+   "execution_count": 3
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's check it's working:"
+    "Let's check the dynamics are working by running one simulation step and checking the potential energy.\n",
+    "\n",
+    "**WARNING**: when accessing data via the `dyn` object, the values we retrieve are in the *units used internally by ASE*. *These units **differ** from those of NanoVer*, so bear this in mind when examining data this way!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:11.188884Z",
+     "start_time": "2024-10-22T14:18:11.136433Z"
     }
    },
+   "source": [
+    "dyn.run(steps = 1)\n",
+    "dyn.get_number_of_steps()"
+   ],
    "outputs": [
     {
      "data": {
@@ -115,24 +135,28 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "dyn.run(steps = 1)\n",
-    "dyn.get_number_of_steps()"
-   ]
+   "execution_count": 4
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:12.642111Z",
+     "start_time": "2024-10-22T14:18:12.638275Z"
     }
    },
+   "source": [
+    "# Note that this is the energy in eV, not kJ mol-1 (the standard units of ASE are different to those of OpenMM and NanoVer)\n",
+    "dyn.atoms.get_potential_energy()"
+   ],
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "-0.18180823716253158"
+       "0.02585199101165164"
       ]
      },
      "execution_count": 5,
@@ -140,37 +164,53 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "# Note that this is the energy in eV, not kJ mol-1 (the standard units of ASE are different to those of OpenMM and NanoVer)\n",
-    "dyn.atoms.get_potential_energy()"
-   ]
+   "execution_count": 5
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Now let's import the `ASESimulation` class: this allows us to pass our ASE molecular dynamics simulation to NanoVer to run an iMD simulation. We can define our `ASESimulation` from the dynamics object we created above, as follows:"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:17.564561Z",
+     "start_time": "2024-10-22T14:18:17.483100Z"
+    }
+   },
    "source": [
     "from nanover.omni.ase import ASESimulation\n",
     "\n",
-    "nanover_imd = ASESimulation.from_ase_dynamics(dyn)"
-   ]
+    "ase_sim = ASESimulation.from_ase_dynamics(dyn)"
+   ],
+   "outputs": [],
+   "execution_count": 6
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's run a couple of steps to make sure it's working"
+    "Let's run a couple of steps to check that everything is still working. \n",
+    "\n",
+    "**NOTE**: the commands below still run the ASE MD simulation directly, (i.e. *NOT* using NanoVer and thus not running an iMD simulation), and the data is still being accessed via the dynamics object defined previously (i.e. `ase_sim.dynamics = dyn`, see above). "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:20.395932Z",
+     "start_time": "2024-10-22T14:18:20.226273Z"
     }
    },
+   "source": [
+    "ase_sim.dynamics.run(10)\n",
+    "ase_sim.dynamics.nsteps"
+   ],
    "outputs": [
     {
      "data": {
@@ -183,20 +223,22 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "nanover_imd.dynamics.run(10)\n",
-    "nanover_imd.dynamics.nsteps"
-   ]
+   "execution_count": 7
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:21.498100Z",
+     "start_time": "2024-10-22T14:18:21.494489Z"
+    }
+   },
+   "source": "ase_sim.dynamics.atoms.get_potential_energy()",
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "-0.18179726385287687"
+       "-0.038808466184859114"
       ]
      },
      "execution_count": 8,
@@ -204,9 +246,12 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "nanover_imd.dynamics.atoms.get_potential_energy()"
-   ]
+   "execution_count": 8
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Great! Everything's working with the `ASESimulation`. Let's turn our attention to setting up the server and running an iMD simulation."
   },
   {
    "cell_type": "markdown",
@@ -218,85 +263,87 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "We fetch the NanoVer object we need to serve the dynamics. We provide a handy wrapper that understands ASE simulations and will serve the dynamics for you."
-   ]
+   "source": "In NanoVer we use the `OmniRunner` class to serve iMD simulations."
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:23.776446Z",
+     "start_time": "2024-10-22T14:18:23.774064Z"
     }
    },
-   "outputs": [],
    "source": [
     "from nanover.omni import OmniRunner"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 9
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Let's set up an IMD server: we set `port=0` to let the operating system pick a free port for us."
-   ]
+   "source": "We set up an iMD simulation by passing the `ASESimulation` defined above to an `OmniRunner`: we set `port=0` to let the operating system pick a free port for us."
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:48.401896Z",
+     "start_time": "2024-10-22T14:18:48.388448Z"
     }
    },
+   "source": "imd_runner = OmniRunner.with_basic_server(ase_sim, port=0, name=\"ase_nanover_server\") #Try using Shift+TAB+TAB to see what you can set up here.",
    "outputs": [],
-   "source": [
-    "runner = OmniRunner.with_basic_server(nanover_imd, port=0) #Try using Shift+TAB+TAB to see what you can set up here."
-   ]
+   "execution_count": 10
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note**: Be careful if you run the above cell multiple times without running `app_server.close()` (see below), as you will start multiple servers, which may be discovered if you use autoconnect. You can guard against this by swapping the cell above with:\n",
+    "**Note**: Be careful if you run the above cell multiple times without running `imd_runner.close()` (see below), as you will start multiple servers, which may be discovered if you use autoconnect. You can guard against this by swapping the cell above with:\n",
     "\n",
     "```python\n",
     "try:\n",
-    "    runner.close()\n",
+    "    imd_runner.close()\n",
     "except NameError: # If the server hasn't been defined yet, there will be an error\n",
     "    pass\n",
-    "runner = OmniRunner.with_basic_server(port=0)\n",
+    "imd_runner = OmniRunner.with_basic_server(ase_sim, port=0)\n",
     "```"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "A server is now ready to be discovered, we can see where it's running with the following:"
-   ]
+   "source": "Our server is now running and discoverable! We can see where it's running by running the following cell:"
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:50.333783Z",
+     "start_time": "2024-10-22T14:18:50.330949Z"
     }
    },
+   "source": "print(f'{imd_runner.app_server.name}: Running at {imd_runner.app_server.address}:{imd_runner.app_server.port}')",
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "harrystroud: NanoVer iMD Server: Running at [::]:63903\n"
+      "ase_nanover_server: Running at [::]:55508\n"
      ]
     }
    ],
-   "source": [
-    "print(f'{runner.app_server.name}: Running at {runner.app_server.address}:{runner.app_server.port}')"
-   ]
+   "execution_count": 11
   },
   {
    "cell_type": "markdown",
@@ -314,41 +361,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:51.914283Z",
+     "start_time": "2024-10-22T14:18:51.900741Z"
+    }
+   },
+   "source": "imd_runner.next()",
    "outputs": [],
-   "source": [
-    "runner.next()"
-   ]
+   "execution_count": 12
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:53.443405Z",
+     "start_time": "2024-10-22T14:18:53.440292Z"
     }
    },
+   "source": [
+    "# print the time to check dynamics is running\n",
+    "print(f'Simulation time: {ase_sim.dynamics.get_time()}, ({ase_sim.dynamics.nsteps} steps)')"
+   ],
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Simulation time: 1.7680850619235313, (18 steps)\n"
+      "Simulation time: 4.61666655057811, (47 steps)\n"
      ]
     }
    ],
-   "source": [
-    "# print the time to check dynamics is running\n",
-    "print(f'Simulation time: {nanover_imd.dynamics.get_time()}, ({nanover_imd.dynamics.nsteps} steps)')"
-   ]
+   "execution_count": 13
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Ok, it's working, so let's leave it running dynamics in background thread. This is what happens by default when you call `run`"
-   ]
+   "source": "Ok, it's working, so let's leave it running dynamics in a background thread. This is what happens by default when you call `.next()`"
   },
   {
    "cell_type": "markdown",
@@ -362,9 +414,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "You can also visualize it live in the notebook, (check out this [example with NGLView](../basics/nanover_nglview.ipynb))."
-   ]
+   "source": "You can also visualize it live from within a Jupyter notebook, (check out this [example with NGLView](../basics/nanover_nglview.ipynb))."
   },
   {
    "cell_type": "markdown",
@@ -376,65 +426,79 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Let's have a look at the data that's being produced here, by connecting a python client"
-   ]
+   "source": "Let's have a look at the data that's being produced here, by connecting a python client to the server running the simulation."
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:57.005418Z",
+     "start_time": "2024-10-22T14:18:56.943096Z"
     }
    },
-   "outputs": [],
    "source": [
     "from nanover.app import NanoverImdClient\n",
-    "client = NanoverImdClient.connect_to_single_server(port=runner.app_server.port)"
-   ]
+    "client = NanoverImdClient.connect_to_single_server(port=imd_runner.app_server.port)"
+   ],
+   "outputs": [],
+   "execution_count": 14
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Subscribe to the stream of frames. The server will try to send 30 frames per seconds, if it produces more frames, some frames will be skipped to maintain the cadence."
-   ]
+   "source": "Subscribe to the stream of frames. By default the server will try to send 30 frames per seconds—if it produces more frames, some frames will be skipped to maintain the cadence."
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:18:59.055698Z",
+     "start_time": "2024-10-22T14:18:59.030294Z"
+    }
+   },
    "source": [
     "client.subscribe_to_frames()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 15
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Let's grab a frame"
-   ]
+   "source": "Let's grab one of the frames and examine some of its values"
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:01.004068Z",
+     "start_time": "2024-10-22T14:19:00.996126Z"
     }
    },
-   "outputs": [],
    "source": [
     "client.wait_until_first_frame()\n",
     "frame = client.current_frame"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 16
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:02.021105Z",
+     "start_time": "2024-10-22T14:19:02.011673Z"
+    }
+   },
+   "source": [
+    "frame.particle_count"
+   ],
    "outputs": [
     {
      "data": {
@@ -447,23 +511,28 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "frame.particle_count"
-   ]
+   "execution_count": 17
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:03.694727Z",
+     "start_time": "2024-10-22T14:19:03.689968Z"
     }
    },
+   "source": [
+    "# Print the potential energy, here in kJ mol-1 as we are accessing it via NanoVer\n",
+    "frame.potential_energy # use TAB to see what's available!"
+   ],
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "-17.533980241570806"
+       "119.54828003152164"
       ]
      },
      "execution_count": 18,
@@ -471,27 +540,33 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "# Print the potential energy, here in kJ mol-1 as we are accessing it via NanoVer\n",
-    "frame.potential_energy # use TAB to see what's available!"
-   ]
+   "execution_count": 18
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also print out the raw underlying data that is sent to VR, and see all the simulation data that is being transmitted"
+    "See here that as we have accessed the potential energy via the frame output by NanoVer, so it is given in NanoVer's standard unit of energy, kJ/mol.\n",
+    "\n",
+    "We can also print out the raw underlying data that is sent from the server to a client, and see all the simulation data that is being transmitted:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
    "metadata": {
     "pycharm": {
      "is_executing": false
     },
-    "scrolled": true
+    "scrolled": true,
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:05.100928Z",
+     "start_time": "2024-10-22T14:19:05.079493Z"
+    }
    },
+   "source": [
+    "# view the latest frame\n",
+    "client.current_frame.raw"
+   ],
    "outputs": [
     {
      "data": {
@@ -505,7 +580,7 @@
        "values {\n",
        "  key: \"server.timestamp\"\n",
        "  value {\n",
-       "    number_value: 71745.708391166\n",
+       "    number_value: 142445.64141025\n",
        "  }\n",
        "}\n",
        "values {\n",
@@ -523,13 +598,13 @@
        "values {\n",
        "  key: \"energy.potential\"\n",
        "  value {\n",
-       "    number_value: -17.532057455938844\n",
+       "    number_value: 135.45548898665891\n",
        "  }\n",
        "}\n",
        "values {\n",
        "  key: \"energy.kinetic\"\n",
        "  value {\n",
-       "    number_value: 0.010858480390873912\n",
+       "    number_value: 105.77865715380986\n",
        "  }\n",
        "}\n",
        "values {\n",
@@ -621,102 +696,102 @@
        "  key: \"particle.positions\"\n",
        "  value {\n",
        "    float_values {\n",
-       "      values: -8.08861296e-05\n",
-       "      values: -7.04341028e-06\n",
-       "      values: 3.44130422e-05\n",
-       "      values: 0.18042554\n",
-       "      values: 0.180388376\n",
-       "      values: -5.42464331e-05\n",
-       "      values: 0.180535182\n",
-       "      values: 4.58165741e-05\n",
-       "      values: 0.180564299\n",
-       "      values: 6.37728881e-05\n",
-       "      values: 0.180476949\n",
-       "      values: 0.180508599\n",
-       "      values: 0.361018121\n",
-       "      values: 2.66284333e-05\n",
-       "      values: -6.3303989e-05\n",
-       "      values: 0.541461766\n",
-       "      values: 0.180484831\n",
-       "      values: 4.9048318e-05\n",
-       "      values: 0.541466117\n",
-       "      values: -3.439801e-05\n",
-       "      values: 0.180518121\n",
-       "      values: 0.360976517\n",
-       "      values: 0.180539131\n",
-       "      values: 0.180530474\n",
-       "      values: 4.32907509e-05\n",
-       "      values: 0.360934794\n",
-       "      values: -9.07003196e-05\n",
-       "      values: 0.180561259\n",
-       "      values: 0.541539\n",
-       "      values: 1.6454569e-05\n",
-       "      values: 0.180554852\n",
-       "      values: 0.361037016\n",
-       "      values: 0.180560142\n",
-       "      values: -5.34986866e-05\n",
-       "      values: 0.541486084\n",
-       "      values: 0.180490911\n",
-       "      values: 0.36085\n",
-       "      values: 0.361027539\n",
-       "      values: 2.54441748e-05\n",
-       "      values: 0.541395843\n",
-       "      values: 0.541514218\n",
-       "      values: 8.32559e-05\n",
-       "      values: 0.541443229\n",
-       "      values: 0.360983938\n",
-       "      values: 0.180545077\n",
-       "      values: 0.361049861\n",
-       "      values: 0.541501701\n",
-       "      values: 0.180474699\n",
-       "      values: 0.000100237128\n",
-       "      values: 6.13787488e-05\n",
-       "      values: 0.360888392\n",
-       "      values: 0.180479616\n",
-       "      values: 0.180498898\n",
-       "      values: 0.360999823\n",
-       "      values: 0.180450305\n",
-       "      values: 6.63495885e-05\n",
-       "      values: 0.541473031\n",
-       "      values: -7.80999617e-05\n",
-       "      values: 0.180430397\n",
-       "      values: 0.54154557\n",
-       "      values: 0.361086\n",
-       "      values: 2.14801639e-05\n",
-       "      values: 0.3610605\n",
-       "      values: 0.541564286\n",
-       "      values: 0.180553809\n",
-       "      values: 0.361035645\n",
-       "      values: 0.54155618\n",
-       "      values: -4.97167057e-05\n",
-       "      values: 0.541514456\n",
-       "      values: 0.361072928\n",
-       "      values: 0.180593193\n",
-       "      values: 0.541416705\n",
-       "      values: -9.44544536e-06\n",
-       "      values: 0.360899121\n",
-       "      values: 0.361074507\n",
-       "      values: 0.180493355\n",
-       "      values: 0.541564882\n",
-       "      values: 0.360985\n",
-       "      values: 0.180486605\n",
-       "      values: 0.360950112\n",
-       "      values: 0.541464865\n",
-       "      values: -2.54885272e-05\n",
-       "      values: 0.541466534\n",
-       "      values: 0.541552067\n",
-       "      values: 0.361087292\n",
-       "      values: 0.36101082\n",
-       "      values: 0.360883027\n",
-       "      values: 0.541595399\n",
-       "      values: 0.541372716\n",
-       "      values: 0.36103496\n",
-       "      values: 0.541488826\n",
-       "      values: 0.361009538\n",
-       "      values: 0.54156816\n",
-       "      values: 0.361011147\n",
-       "      values: 0.541493833\n",
-       "      values: 0.541347742\n",
+       "      values: -0.0133140981\n",
+       "      values: -0.00766365137\n",
+       "      values: -0.0104424926\n",
+       "      values: 0.179153115\n",
+       "      values: 0.176403657\n",
+       "      values: -0.0134923551\n",
+       "      values: 0.171155185\n",
+       "      values: -0.00858240668\n",
+       "      values: 0.178848684\n",
+       "      values: 0.00273266225\n",
+       "      values: 0.181012541\n",
+       "      values: 0.17874825\n",
+       "      values: 0.366316348\n",
+       "      values: 0.00643992331\n",
+       "      values: -0.00141748867\n",
+       "      values: 0.54726094\n",
+       "      values: 0.184739783\n",
+       "      values: -0.00710130297\n",
+       "      values: 0.545588255\n",
+       "      values: 0.0141852619\n",
+       "      values: 0.176963776\n",
+       "      values: 0.341915965\n",
+       "      values: 0.175071254\n",
+       "      values: 0.179079801\n",
+       "      values: -0.00350318127\n",
+       "      values: 0.369710326\n",
+       "      values: 0.00202661636\n",
+       "      values: 0.181517228\n",
+       "      values: 0.548425376\n",
+       "      values: 0.00900510792\n",
+       "      values: 0.190544471\n",
+       "      values: 0.366914839\n",
+       "      values: 0.178774521\n",
+       "      values: 0.00440142024\n",
+       "      values: 0.553927302\n",
+       "      values: 0.171775684\n",
+       "      values: 0.364547968\n",
+       "      values: 0.361045539\n",
+       "      values: 0.00118278409\n",
+       "      values: 0.535368\n",
+       "      values: 0.536587179\n",
+       "      values: 0.0107315313\n",
+       "      values: 0.531056702\n",
+       "      values: 0.354211539\n",
+       "      values: 0.176612183\n",
+       "      values: 0.361485124\n",
+       "      values: 0.548688293\n",
+       "      values: 0.196089834\n",
+       "      values: 0.0107216118\n",
+       "      values: -0.0105181905\n",
+       "      values: 0.364526421\n",
+       "      values: 0.182667702\n",
+       "      values: 0.181639344\n",
+       "      values: 0.347895473\n",
+       "      values: 0.174884602\n",
+       "      values: 0.00093098561\n",
+       "      values: 0.542361081\n",
+       "      values: 0.0105485553\n",
+       "      values: 0.1714347\n",
+       "      values: 0.538261652\n",
+       "      values: 0.360256135\n",
+       "      values: 0.0134647423\n",
+       "      values: 0.360356927\n",
+       "      values: 0.549165249\n",
+       "      values: 0.169022441\n",
+       "      values: 0.371956766\n",
+       "      values: 0.534279048\n",
+       "      values: -0.00378586934\n",
+       "      values: 0.551949143\n",
+       "      values: 0.362706631\n",
+       "      values: 0.193328977\n",
+       "      values: 0.538634181\n",
+       "      values: -0.00305899535\n",
+       "      values: 0.36215505\n",
+       "      values: 0.353945\n",
+       "      values: 0.17903614\n",
+       "      values: 0.536572695\n",
+       "      values: 0.363334745\n",
+       "      values: 0.164779693\n",
+       "      values: 0.364519358\n",
+       "      values: 0.54593271\n",
+       "      values: -0.00599109242\n",
+       "      values: 0.532963336\n",
+       "      values: 0.541601\n",
+       "      values: 0.368180722\n",
+       "      values: 0.346316367\n",
+       "      values: 0.35605374\n",
+       "      values: 0.54341352\n",
+       "      values: 0.551780164\n",
+       "      values: 0.373202085\n",
+       "      values: 0.551153481\n",
+       "      values: 0.361339658\n",
+       "      values: 0.544141471\n",
+       "      values: 0.364913553\n",
+       "      values: 0.537256181\n",
+       "      values: 0.535757899\n",
        "    }\n",
        "  }\n",
        "}\n",
@@ -820,10 +895,7 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "# view the latest frame\n",
-    "client.current_frame.raw"
-   ]
+   "execution_count": 19
   },
   {
    "cell_type": "markdown",
@@ -834,39 +906,45 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:07.633832Z",
+     "start_time": "2024-10-22T14:19:07.615895Z"
     }
    },
-   "outputs": [],
    "source": [
     "from nanover.ase.converter import frame_data_to_ase\n",
     "atoms = frame_data_to_ase(client.first_frame, topology=True, positions=False)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 20
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "We can run this to update the latest positions from the frame (note that NanoVer uses **nanometers** for positions. [Why??](http://docs.openmm.org/6.2.0/userguide/theory.html#units))"
-   ]
+   "source": "We can run this to update the latest positions from the frame (note that NanoVer uses **nanometers** for positions ([the same as OpenMM](http://docs.openmm.org/6.2.0/userguide/theory.html#units)), so we need to convert back to Angstrom to visualise the system using ASE.)"
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:09.050569Z",
+     "start_time": "2024-10-22T14:19:09.036881Z"
     }
    },
-   "outputs": [],
    "source": [
     "import numpy as np\n",
     "# set the positions to match the latest frame data\n",
     "atoms.set_positions(np.array(client.latest_frame.particle_positions) * 10)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 21
   },
   {
    "cell_type": "markdown",
@@ -877,12 +955,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:10.300274Z",
+     "start_time": "2024-10-22T14:19:10.268108Z"
     }
    },
+   "source": [
+    "from ase.visualize import view\n",
+    "view(atoms)"
+   ],
    "outputs": [
     {
      "data": {
@@ -895,10 +980,7 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "from ase.visualize import view\n",
-    "view(atoms)"
-   ]
+   "execution_count": 22
   },
   {
    "cell_type": "markdown",
@@ -909,15 +991,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:14.876880Z",
+     "start_time": "2024-10-22T14:19:14.819077Z"
     }
    },
+   "source": [
+    "view(atoms, viewer='x3d')"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ],
       "text/html": [
        "<html>\n",
        "\n",
@@ -945,7 +1036,7 @@
        "\n",
        "   <Scene>\n",
        "\n",
-       "    <Transform translation=\"-0.00 0.00 0.00\">\n",
+       "    <Transform translation=\"-0.07 -0.06 -0.00\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -965,7 +1056,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"1.80 1.80 -0.00\">\n",
+       "    <Transform translation=\"1.76 1.78 0.01\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -985,7 +1076,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"1.80 -0.00 1.80\">\n",
+       "    <Transform translation=\"1.83 -0.04 1.86\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1005,7 +1096,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"0.00 1.80 1.81\">\n",
+       "    <Transform translation=\"0.02 1.86 1.70\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1025,7 +1116,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"3.61 0.00 -0.00\">\n",
+       "    <Transform translation=\"3.56 0.10 0.02\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1045,7 +1136,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"5.41 1.81 0.00\">\n",
+       "    <Transform translation=\"5.39 1.83 -0.12\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1065,7 +1156,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"5.41 -0.00 1.81\">\n",
+       "    <Transform translation=\"5.34 0.16 1.91\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1085,7 +1176,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"3.61 1.81 1.81\">\n",
+       "    <Transform translation=\"3.51 1.85 1.81\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1105,7 +1196,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"0.00 3.61 0.00\">\n",
+       "    <Transform translation=\"-0.05 3.66 -0.01\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1125,7 +1216,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"1.81 5.42 -0.00\">\n",
+       "    <Transform translation=\"1.93 5.43 0.00\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1145,7 +1236,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"1.81 3.61 1.81\">\n",
+       "    <Transform translation=\"1.84 3.75 1.69\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1165,7 +1256,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"-0.00 5.41 1.80\">\n",
+       "    <Transform translation=\"-0.01 5.46 1.64\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1185,7 +1276,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"3.61 3.61 0.00\">\n",
+       "    <Transform translation=\"3.63 3.62 -0.08\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1205,7 +1296,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"5.41 5.41 0.00\">\n",
+       "    <Transform translation=\"5.28 5.38 0.00\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1225,7 +1316,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"5.42 3.61 1.81\">\n",
+       "    <Transform translation=\"5.39 3.48 1.74\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1245,7 +1336,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"3.61 5.42 1.80\">\n",
+       "    <Transform translation=\"3.65 5.51 1.92\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1265,7 +1356,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"-0.00 0.00 3.61\">\n",
+       "    <Transform translation=\"0.01 -0.01 3.64\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1285,7 +1376,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"1.80 1.80 3.61\">\n",
+       "    <Transform translation=\"1.76 1.93 3.62\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1305,7 +1396,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"1.80 0.00 5.41\">\n",
+       "    <Transform translation=\"1.81 -0.08 5.42\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1325,7 +1416,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"-0.00 1.81 5.42\">\n",
+       "    <Transform translation=\"0.07 1.73 5.46\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1345,7 +1436,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"3.61 -0.00 3.61\">\n",
+       "    <Transform translation=\"3.63 0.09 3.70\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1365,7 +1456,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"5.42 1.81 3.61\">\n",
+       "    <Transform translation=\"5.54 1.79 3.69\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1385,7 +1476,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"5.42 -0.00 5.42\">\n",
+       "    <Transform translation=\"5.35 0.00 5.38\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1405,7 +1496,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"3.61 1.81 5.41\">\n",
+       "    <Transform translation=\"3.66 1.72 5.35\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1425,7 +1516,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"0.00 3.61 3.61\">\n",
+       "    <Transform translation=\"-0.02 3.51 3.58\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1445,7 +1536,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"1.81 5.42 3.61\">\n",
+       "    <Transform translation=\"1.76 5.40 3.53\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1465,7 +1556,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"1.80 3.61 5.41\">\n",
+       "    <Transform translation=\"1.75 3.57 5.49\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1485,7 +1576,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"-0.00 5.41 5.42\">\n",
+       "    <Transform translation=\"0.04 5.34 5.48\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1505,7 +1596,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"3.61 3.61 3.61\">\n",
+       "    <Transform translation=\"3.73 3.58 3.59\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1525,7 +1616,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"5.42 5.41 3.61\">\n",
+       "    <Transform translation=\"5.41 5.37 3.74\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1545,7 +1636,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"5.42 3.61 5.42\">\n",
+       "    <Transform translation=\"5.46 3.58 5.40\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1565,7 +1656,7 @@
        "\n",
        "    </Transform>\n",
        "\n",
-       "    <Transform translation=\"3.61 5.41 5.41\">\n",
+       "    <Transform translation=\"3.57 5.35 5.38\">\n",
        "\n",
        "     <Shape>\n",
        "\n",
@@ -1593,9 +1684,6 @@
        "\n",
        "</html>\n",
        "\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
       ]
      },
      "execution_count": 23,
@@ -1603,9 +1691,7 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "view(atoms, viewer='x3d')"
-   ]
+   "execution_count": 23
   },
   {
    "cell_type": "markdown",
@@ -1617,22 +1703,22 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "It is very important to close your servers, otherwise they'll get in the way by blocking ports, and your clients may autoconnect to the wrong server!"
-   ]
+   "source": "It is very important to close your servers, otherwise they'll get in the way by blocking ports, and your clients may autoconnect to the wrong server! We close the server calling `.close()`"
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:18.469941Z",
+     "start_time": "2024-10-22T14:19:18.228251Z"
     }
    },
+   "source": "imd_runner.close()",
    "outputs": [],
-   "source": [
-    "runner.close()"
-   ]
+   "execution_count": 24
   },
   {
    "cell_type": "markdown",
@@ -1647,17 +1733,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
    "metadata": {
     "pycharm": {
      "is_executing": false
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-22T14:19:20.571930Z",
+     "start_time": "2024-10-22T14:19:19.923423Z"
     }
    },
-   "outputs": [],
    "source": [
-    "with OmniRunner.with_basic_server(ASESimulation.from_ase_dynamics(dyn), port=0) as runner:\n",
-    "    runner.next()"
-   ]
+    "with OmniRunner.with_basic_server(ASESimulation.from_ase_dynamics(dyn), port=0) as imd_runner:\n",
+    "    imd_runner.next()"
+   ],
+   "outputs": [],
+   "execution_count": 25
   },
   {
    "cell_type": "markdown",
@@ -1669,10 +1759,11 @@
    "source": [
     "# Next Steps\n",
     "\n",
-    "This notebook showed a toy example with ASE. \n",
+    "This notebook demonstrated how to use NanoVer to run iMD simulations using ASE for a toy system. There's plenty more that can be done!\n",
     "\n",
-    "* Run bigger molecular mechanics simulations with OpenMM. The [nanotube](./ase_openmm_nanotube.ipynb) and [neuraminidase](./ase_openmm_neuraminidase.ipynb) examples show how to set up simulations with OpenMM.\n",
-    "* To understand what's going on under the hood, consider starting with the [NanoVer frame explained](../fundamentals/frame.ipynb) example. "
+    "* Run bigger molecular mechanics simulations using OpenMM. The [nanotube](./ase_openmm_nanotube.ipynb) and [neuraminidase](./ase_openmm_neuraminidase.ipynb) examples show how to set up simulations that combine OpenMM with ASE.\n",
+    "* Use the functionality of ASE change the parameters of an OpenMM simulation on the fly. See the [graphene](./ase_openmm_graphene.ipynb) example.\n",
+    "* To understand what's going on under the hood, check out the [NanoVer frame explained](../fundamentals/frame.ipynb) example. "
    ]
   }
  ],

--- a/examples/ase/ase_openmm_graphene.ipynb
+++ b/examples/ase/ase_openmm_graphene.ipynb
@@ -227,9 +227,9 @@
     "graphene_ase_omm_sim.time_step = 0.05\n",
     "\n",
     "# Pass the simulation to the OmniRunner, load the simulation and pause it\n",
-    "runner = OmniRunner.with_basic_server(graphene_ase_omm_sim, name=\"graphene-ase-omm-server\", port=0)\n",
-    "runner.next()\n",
-    "runner.pause()"
+    "imd_runner = OmniRunner.with_basic_server(graphene_ase_omm_sim, name=\"graphene-ase-omm-server\", port=0)\n",
+    "imd_runner.next()\n",
+    "imd_runner.pause()"
    ]
   },
   {
@@ -325,7 +325,7 @@
    "outputs": [],
    "source": [
     "# Start running the simulation\n",
-    "runner.play()"
+    "imd_runner.play()"
    ]
   },
   {
@@ -348,9 +348,7 @@
      ]
     }
    ],
-   "source": [
-    "print(f'{runner.app_server.name}: serving on {runner.app_server.address}:{runner.app_server.port}')"
-   ]
+   "source": "print(f'{imd_runner.app_server.name}: serving on {imd_runner.app_server.address}:{imd_runner.app_server.port}')"
   },
   {
    "cell_type": "markdown",
@@ -569,14 +567,14 @@
     "\n",
     "def on_reset_clicked(b):\n",
     "    with output:\n",
-    "        runner.reset()\n",
+    "        imd_runner.reset()\n",
     "\n",
     "def on_play_clicked(obj):\n",
     "    with output:\n",
     "        if obj['new']:  \n",
-    "            runner.play()\n",
+    "            imd_runner.play()\n",
     "        else:\n",
-    "            runner.pause()\n",
+    "            imd_runner.pause()\n",
     "\n",
     "reset_button.on_click(on_reset_clicked)\n",
     "play_button.observe(on_play_clicked, 'value')"
@@ -626,13 +624,13 @@
     "# the following line unregisters the commands if they've already been registered. \n",
     "for command in [TIMESTEP_COMMAND, FRICTION_COMMAND, TEMPERATURE_COMMAND]:\n",
     "    try:\n",
-    "        runner.app_server.server.unregister_command(command)\n",
+    "        imd_runner.app_server.server.unregister_command(command)\n",
     "    except:\n",
     "        pass\n",
     "\n",
-    "runner.app_server.server.register_command(TIMESTEP_COMMAND, set_timestep)\n",
-    "runner.app_server.server.register_command(TEMPERATURE_COMMAND, set_temperature)\n",
-    "runner.app_server.server.register_command(FRICTION_COMMAND, set_friction)"
+    "imd_runner.app_server.server.register_command(TIMESTEP_COMMAND, set_timestep)\n",
+    "imd_runner.app_server.server.register_command(TEMPERATURE_COMMAND, set_temperature)\n",
+    "imd_runner.app_server.server.register_command(FRICTION_COMMAND, set_friction)"
    ]
   },
   {
@@ -649,7 +647,7 @@
    "outputs": [],
    "source": [
     "from nanover.app import NanoverImdClient\n",
-    "client =  NanoverImdClient.connect_to_single_server(port=runner.app_server.port)    "
+    "client =  NanoverImdClient.connect_to_single_server(port=imd_runner.app_server.port)"
    ]
   },
   {
@@ -734,7 +732,7 @@
    "outputs": [],
    "source": [
     "client.close()\n",
-    "runner.close()"
+    "imd_runner.close()"
    ]
   },
   {

--- a/examples/ase/ase_openmm_neuraminidase.ipynb
+++ b/examples/ase/ase_openmm_neuraminidase.ipynb
@@ -336,9 +336,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "**Note**: Here we use OpenMM to calculate the forces and ASE as the integrator. The `narupa-openmm` package lets you use OpenMM for the integrator as well. See the `nanover-omm-server` command."
-   ]
+   "source": "**Note**: Here we use OpenMM to calculate the forces and ASE as the integrator. The `nanover-openmm` package lets you use OpenMM for the integrator as well. See the `OpenMMSimulation` class."
   },
   {
    "cell_type": "markdown",
@@ -460,11 +458,11 @@
    },
    "outputs": [],
    "source": [
-    "omni_sim = ASESimulation.from_ase_dynamics(\n",
+    "ase_sim = ASESimulation.from_ase_dynamics(\n",
     "    dynamics, \n",
     "    ase_atoms_to_frame_data=openmm_ase_atoms_to_frame_data,\n",
     ")\n",
-    "omni = OmniRunner.with_basic_server(omni_sim)"
+    "imd_runner = OmniRunner.with_basic_server(ase_sim)"
    ]
   },
   {
@@ -496,8 +494,8 @@
     }
    ],
    "source": [
-    "omni_sim.dynamics.run(100)\n",
-    "omni_sim.atoms.get_potential_energy()"
+    "ase_sim.dynamics.run(100)\n",
+    "ase_sim.atoms.get_potential_energy()"
    ]
   },
   {
@@ -517,9 +515,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "omni.next()"
-   ]
+   "source": "imd_runner.next()"
   },
   {
    "cell_type": "markdown",
@@ -563,7 +559,7 @@
    "outputs": [],
    "source": [
     "from nanover.app import NanoverImdClient\n",
-    "client = NanoverImdClient.connect_to_single_server(port=omni.app_server.port)\n",
+    "client = NanoverImdClient.connect_to_single_server(port=imd_runner.app_server.port)\n",
     "client.subscribe_to_frames()\n",
     "client.wait_until_first_frame();"
    ]
@@ -779,7 +775,7 @@
    "outputs": [],
    "source": [
     "client.close()\n",
-    "omni.close()"
+    "imd_runner.close()"
    ]
   },
   {

--- a/examples/ase/ase_openmm_neuraminidase.ipynb
+++ b/examples/ase/ase_openmm_neuraminidase.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "# Setting up an OpenMM iMD simulation"
-   ]
+   "source": "# Setting up an OpenMM iMD simulation with ASE and NanoVer"
   },
   {
    "cell_type": "markdown",
@@ -13,7 +11,7 @@
    "source": [
     "This notebook demonstrates how to set up an OpenMM simulation for use with NanoVer from scratch.\n",
     "We take AMBER files for neuraminidase with oseltamivir (AKA tamiflu) bound, create an OpenMM system and \n",
-    "set it up with NanoVer, using ASE as the integrator"
+    "set it up with NanoVer, using ASE as the integrator for the interactive molecular dynamics (iMD) simulation. "
    ]
   },
   {
@@ -44,40 +42,38 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "We start by creating an OpenMM simulation from our AMBER files. OpenMM also supports Gromacs and CHARMM files, and can be customized for many other uses. "
-   ]
+   "source": "We start by creating an OpenMM simulation for the neuraminidase-oseltamivir system using the relevant pre-prepared AMBER files. OpenMM also supports Gromacs and CHARMM files, and can be customized for many other uses. "
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:37.212605Z",
-     "start_time": "2024-10-11T11:02:36.898363Z"
+     "end_time": "2024-10-23T09:54:43.257928Z",
+     "start_time": "2024-10-23T09:54:43.143406Z"
     }
    },
-   "outputs": [],
    "source": [
     "import openmm as mm\n",
     "import openmm.unit as unit \n",
     "import openmm.app as app"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 1
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:37.999054Z",
-     "start_time": "2024-10-11T11:02:37.749626Z"
+     "end_time": "2024-10-23T09:54:43.421869Z",
+     "start_time": "2024-10-23T09:54:43.270217Z"
     }
    },
-   "outputs": [],
    "source": [
     "prmtop = app.AmberPrmtopFile(\"openmm_files/3TI6_ose_wt.top\")\n",
     "amber_coords = app.AmberInpcrdFile(\"openmm_files/3TI6_ose_wt.rst\")"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 2
   },
   {
    "cell_type": "markdown",
@@ -103,19 +99,22 @@
      "is_executing": false
     }
    },
-   "source": [
-    "Because we use ASE for integrating, we keep the simulation simple by using implicit solvent and no constraints"
-   ]
+   "source": "Because we are going to use ASE to integrate the equations of motion, we keep the simulation simple by using implicit solvent and no constraints."
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:39.650723Z",
-     "start_time": "2024-10-11T11:02:39.461710Z"
+     "end_time": "2024-10-23T09:54:44.004724Z",
+     "start_time": "2024-10-23T09:54:43.894049Z"
     }
    },
+   "source": [
+    "system = prmtop.createSystem(nonbondedMethod=app.CutoffPeriodic, \n",
+    "                             nonbondedCutoff=2*unit.nanometer, \n",
+    "                             implicitSolvent=app.OBC2,\n",
+    "                             constraints=None)"
+   ],
    "outputs": [
     {
      "name": "stderr",
@@ -126,156 +125,148 @@
      ]
     }
    ],
-   "source": [
-    "system = prmtop.createSystem(nonbondedMethod=app.CutoffPeriodic, \n",
-    "                             nonbondedCutoff=2*unit.nanometer, \n",
-    "                             implicitSolvent=app.OBC2,\n",
-    "                             constraints=None)"
-   ]
+   "execution_count": 3
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "To construct an input file for an OpenMM simulation in NanoVer, we need to define an integrator. We will also use this integrator to equilibrate the simulation before saving it to an input file. However, *these parameters are not currently passed to ASE* (as the set of integrators offered by OpenMM and ASE differ), so we will need to define the ASE integrator explicitly later on."
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:42.514705Z",
-     "start_time": "2024-10-11T11:02:42.510481Z"
-    },
     "pycharm": {
      "is_executing": true
+    },
+    "ExecuteTime": {
+     "end_time": "2024-10-23T09:54:48.453962Z",
+     "start_time": "2024-10-23T09:54:48.451349Z"
     }
    },
+   "source": "integrator = mm.LangevinIntegrator(300*unit.kelvin, 1/unit.picosecond, 0.001*unit.picoseconds)",
    "outputs": [],
-   "source": [
-    "integrator = mm.LangevinIntegrator(300*unit.kelvin, 1/unit.picosecond, 0.001*unit.picoseconds)"
-   ]
+   "execution_count": 4
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Create an OpenMM simulation out of the topology, system and integrator"
-   ]
+   "source": "Now we create an OpenMM simulation from the topology, system and integrator that we have defined, and define the positions using the AMBER input coordinate file."
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:44.327171Z",
-     "start_time": "2024-10-11T11:02:44.225632Z"
+     "end_time": "2024-10-23T09:54:49.567317Z",
+     "start_time": "2024-10-23T09:54:49.465378Z"
     }
    },
-   "outputs": [],
    "source": [
     "simulation = app.Simulation(prmtop.topology, system, integrator)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 5
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:45.946111Z",
-     "start_time": "2024-10-11T11:02:45.929227Z"
+     "end_time": "2024-10-23T09:54:50.784486Z",
+     "start_time": "2024-10-23T09:54:50.766631Z"
     }
    },
-   "outputs": [],
    "source": [
     "simulation.context.setPositions(amber_coords.positions)\n",
     "if amber_coords.boxVectors is not None:\n",
     "    simulation.context.setPeriodicBoxVectors(*amber_coords.boxVectors)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 6
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Minimize the energy to create a stable conformation"
-   ]
+   "source": "Let's minimize the energy to create a stable conformation that can be used to run dynamics:"
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:48.726771Z",
-     "start_time": "2024-10-11T11:02:47.571332Z"
+     "end_time": "2024-10-23T09:54:53.233977Z",
+     "start_time": "2024-10-23T09:54:52.510258Z"
     }
    },
-   "outputs": [],
    "source": [
     "simulation.minimizeEnergy()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 7
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Run a few steps to check it's stable"
-   ]
+   "source": "Now let's run a few steps to check it's stable, printing the potential energy and temperature every 500 steps."
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:49.802180Z",
-     "start_time": "2024-10-11T11:02:49.779330Z"
+     "end_time": "2024-10-23T09:54:53.662204Z",
+     "start_time": "2024-10-23T09:54:53.650239Z"
     }
    },
-   "outputs": [],
    "source": [
     "simulation.context.setVelocitiesToTemperature(300 * unit.kelvin)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 8
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:51.579581Z",
-     "start_time": "2024-10-11T11:02:51.576491Z"
+     "end_time": "2024-10-23T09:54:55.510355Z",
+     "start_time": "2024-10-23T09:54:55.508141Z"
     }
    },
-   "outputs": [],
    "source": [
     "import sys"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 9
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:02:58.583405Z",
-     "start_time": "2024-10-11T11:02:52.972305Z"
+     "end_time": "2024-10-23T09:55:03.139261Z",
+     "start_time": "2024-10-23T09:54:56.690113Z"
     }
    },
+   "source": [
+    "simulation.reporters.append(app.StateDataReporter(sys.stdout, 500, step=True,\n",
+    "        potentialEnergy=True, temperature=True))\n",
+    "simulation.step(5000)"
+   ],
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "#\"Step\",\"Potential Energy (kJ/mole)\",\"Temperature (K)\"\n",
-      "100,-39686.99454520368,171.15355646771883\n",
-      "200,-37969.39191458844,174.47405302152586\n",
-      "300,-36926.46134207868,185.81969663776286\n",
-      "400,-36312.37470267438,197.06870343518318\n",
-      "500,-35988.50852225446,211.3250616837355\n",
-      "600,-35148.14240286969,216.96937436728012\n",
-      "700,-34459.43003104352,223.55437355836068\n",
-      "800,-34169.05051444196,232.81622289859095\n",
-      "900,-33392.66649649762,234.1818586856779\n",
-      "1000,-33060.31974051618,244.3846325582557\n"
+      "500,-35892.80851004743,208.75830794933293\n",
+      "1000,-33098.39441702985,243.0947096638716\n",
+      "1500,-31567.636558753482,265.3980710461487\n",
+      "2000,-30357.08402274274,277.1831587655949\n",
+      "2500,-29505.31430838727,283.0251879352551\n",
+      "3000,-29421.981117469302,292.1731576697053\n",
+      "3500,-29400.87766287946,295.71076744311154\n",
+      "4000,-28972.899574500552,292.206369629022\n",
+      "4500,-28670.388008338443,297.33164775276924\n",
+      "5000,-28895.867256385318,299.738964317865\n"
      ]
     }
    ],
-   "source": [
-    "simulation.reporters.append(app.StateDataReporter(sys.stdout, 100, step=True,\n",
-    "        potentialEnergy=True, temperature=True))\n",
-    "simulation.step(1000)"
-   ]
+   "execution_count": 10
   },
   {
    "cell_type": "markdown",
@@ -287,30 +278,24 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "The following cell outputs the system as an OpenMM XML file + a PDB file with the topology. This let's you take what you've done here and use it straight in NanoVer elsewhere, perfect if you just want to run a simulation quickly: \n",
-    "\n",
-    "```bash \n",
-    "nanover-omm-ase neuraminidase_nanover.xml\n",
-    "```"
-   ]
+   "source": "The following cell outputs the system as an OpenMM XML file + a PDB file with the topology. This let's you save what you've done here to an input file, so you can load the simulation immediately for use in NanoVer without having to reconstruct the simulation."
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:04.176799Z",
-     "start_time": "2024-10-11T11:03:01.073873Z"
+     "end_time": "2024-10-23T09:55:04.710058Z",
+     "start_time": "2024-10-23T09:55:03.142909Z"
     }
    },
-   "outputs": [],
    "source": [
     "from nanover.openmm.serializer import serialize_simulation\n",
     "\n",
     "with open('neuraminidase_nanover.xml','w') as f:\n",
     "    f.write(serialize_simulation(simulation))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 11
   },
   {
    "cell_type": "markdown",
@@ -330,13 +315,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that we've got an OpenMM simulation, let's pair it with ASE so we can do interactive molecular dynamics with NanoVer."
+    "Now that we've got an OpenMM simulation, let's pair it with ASE so we can do interactive molecular dynamics with NanoVer. \n",
+    "\n",
+    "This setup uses both ASE and OpenMM to perform the iMD simulation:\n",
+    "* OpenMM calculates the forces acting on the system (i.e. the \"calculator\" for ASE defined in NanoVer)\n",
+    "* ASE performs the integration of the equations of motion"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": "**Note**: Here we use OpenMM to calculate the forces and ASE as the integrator. The `nanover-openmm` package lets you use OpenMM for the integrator as well. See the `OpenMMSimulation` class."
+   "source": "**Note**: The `nanover-openmm` package lets you use the inbuilt integrators in OpenMM to perform iMD simulations. These types of are defined using the `OpenMMSimulation` class: for more information on this approach, see the tutorials in the [OpenMM directory](../openmm)."
   },
   {
    "cell_type": "markdown",
@@ -348,47 +337,51 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "We use the OpenMMCalculator to take our simulation and produce an ASE Atoms object"
-   ]
+   "source": "We use the `OpenMMCalculator` class to take our simulation and produce an ASE Atoms object. We then assign the `OpenMMCalculator` as the calculator for the simulation—this tells ASE that we're using OpenMM to calculate the forces that ASE will use to integrate the equations of motion."
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:08.198123Z",
-     "start_time": "2024-10-11T11:03:07.931047Z"
+     "end_time": "2024-10-23T09:55:08.950037Z",
+     "start_time": "2024-10-23T09:55:08.816053Z"
     }
    },
-   "outputs": [],
    "source": [
     "from nanover.ase.openmm import OpenMMCalculator"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:10.021005Z",
-     "start_time": "2024-10-11T11:03:10.017521Z"
-    }
-   },
+   ],
    "outputs": [],
-   "source": [
-    "calculator = OpenMMCalculator(simulation)"
-   ]
+   "execution_count": 12
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:11.841719Z",
-     "start_time": "2024-10-11T11:03:11.574654Z"
+     "end_time": "2024-10-23T09:55:09.801767Z",
+     "start_time": "2024-10-23T09:55:09.799305Z"
     }
    },
+   "source": [
+    "# Define the calculator using the OpenMM simulation defined above\n",
+    "calculator = OpenMMCalculator(simulation)"
+   ],
+   "outputs": [],
+   "execution_count": 13
+  },
+  {
+   "cell_type": "code",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-10-23T09:55:11.040545Z",
+     "start_time": "2024-10-23T09:55:10.856862Z"
+    }
+   },
+   "source": [
+    "# Define the atoms object and set it's calculator as the OpenMMCalculator\n",
+    "atoms = calculator.generate_atoms()\n",
+    "atoms.calc = calculator\n",
+    "len(atoms)"
+   ],
    "outputs": [
     {
      "data": {
@@ -401,69 +394,65 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "atoms = calculator.generate_atoms()\n",
-    "atoms.set_calculator(calculator)\n",
-    "len(atoms)"
-   ]
+   "execution_count": 14
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we've got an ASE Atoms object, and a calculator, we can set up NanoVer with ASE as [usual](./ase_basic_example.ipynb). \n",
-    "The only difference here is that we swap out the default way of sending frames with a specially made one, `openmm_ase_frame_adaptor`, for OpenMM that knows about OpenMM topology"
+    "Now we've got an ASE Atoms object, and a calculator, we can set up NanoVer with ASE as usual. \n",
+    "The key difference between this setup and the [basic ASE tutorial](./ase_basic_example.ipynb) is that we swap out the default way of sending frames with a specially made one, `openmm_ase_atoms_to_frame_data`, that knows about OpenMM topology."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:13.895040Z",
-     "start_time": "2024-10-11T11:03:13.889625Z"
+     "end_time": "2024-10-23T09:55:13.613918Z",
+     "start_time": "2024-10-23T09:55:13.610330Z"
     }
    },
-   "outputs": [],
    "source": [
     "from ase.md import Langevin\n",
     "import ase.units as ase_units\n",
     "dynamics = Langevin(atoms, timestep=1.0 * ase_units.fs, temperature_K=300, friction=1.0e-03)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 15
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:19.899207Z",
-     "start_time": "2024-10-11T11:03:19.894562Z"
+     "end_time": "2024-10-23T09:55:14.767923Z",
+     "start_time": "2024-10-23T09:55:14.761387Z"
     }
    },
-   "outputs": [],
    "source": [
     "from nanover.ase.openmm.frame_adaptor import openmm_ase_atoms_to_frame_data\n",
     "from nanover.omni import OmniRunner\n",
     "from nanover.omni.ase import ASESimulation"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 16
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:21.800989Z",
-     "start_time": "2024-10-11T11:03:21.762441Z"
+     "end_time": "2024-10-23T09:55:15.848633Z",
+     "start_time": "2024-10-23T09:55:15.838211Z"
     }
    },
-   "outputs": [],
    "source": [
     "ase_sim = ASESimulation.from_ase_dynamics(\n",
     "    dynamics, \n",
     "    ase_atoms_to_frame_data=openmm_ase_atoms_to_frame_data,\n",
     ")\n",
     "imd_runner = OmniRunner.with_basic_server(ase_sim)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 17
   },
   {
    "cell_type": "markdown",
@@ -474,18 +463,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:25.543985Z",
-     "start_time": "2024-10-11T11:03:24.067230Z"
+     "end_time": "2024-10-23T09:55:24.067787Z",
+     "start_time": "2024-10-23T09:55:23.172441Z"
     }
    },
+   "source": [
+    "ase_sim.dynamics.run(100)\n",
+    "ase_sim.atoms.get_potential_energy()"
+   ],
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "-431.0731347117381"
+       "-410.4492109598051"
       ]
      },
      "execution_count": 18,
@@ -493,29 +485,24 @@
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "ase_sim.dynamics.run(100)\n",
-    "ase_sim.atoms.get_potential_energy()"
-   ]
+   "execution_count": 18
   },
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "All good! Let's leave it running in the background"
-   ]
+   "source": "All good! Let's leave the simulation running in the background"
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:27.561636Z",
-     "start_time": "2024-10-11T11:03:27.550961Z"
+     "end_time": "2024-10-23T09:57:48.531051Z",
+     "start_time": "2024-10-23T09:57:48.526457Z"
     }
    },
+   "source": "imd_runner.next()",
    "outputs": [],
-   "source": "imd_runner.next()"
+   "execution_count": 19
   },
   {
    "cell_type": "markdown",
@@ -543,26 +530,24 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "First, we connect a client so we can modify the shared state"
-   ]
+   "source": "First, we connect a client so we can modify the shared state, which contains the information defining how NanoVer should render the system for VR clients connecting to the server."
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:44.647191Z",
-     "start_time": "2024-10-11T11:03:44.611045Z"
+     "end_time": "2024-10-23T10:00:49.705665Z",
+     "start_time": "2024-10-23T10:00:49.674548Z"
     }
    },
-   "outputs": [],
    "source": [
     "from nanover.app import NanoverImdClient\n",
     "client = NanoverImdClient.connect_to_single_server(port=imd_runner.app_server.port)\n",
     "client.subscribe_to_frames()\n",
     "client.wait_until_first_frame();"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 20
   },
   {
    "cell_type": "markdown",
@@ -573,39 +558,39 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:46.675877Z",
-     "start_time": "2024-10-11T11:03:46.488107Z"
+     "end_time": "2024-10-23T10:01:14.987408Z",
+     "start_time": "2024-10-23T10:01:14.891855Z"
     }
    },
-   "outputs": [],
    "source": [
     "import matplotlib.cm\n",
     "\n",
     "def get_matplotlib_gradient(name: str):\n",
     "    cmap = matplotlib.colormaps[name]\n",
     "    return list(list(cmap(x/7)) for x in range(0, 8, 1))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 21
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:48.580877Z",
-     "start_time": "2024-10-11T11:03:48.086332Z"
+     "end_time": "2024-10-23T10:01:20.261416Z",
+     "start_time": "2024-10-23T10:01:19.930996Z"
     }
    },
-   "outputs": [],
    "source": [
     "from nanover.mdanalysis import frame_data_to_mdanalysis\n",
     "def generate_mdanalysis_selection(selection: str):\n",
     "    universe = frame_data_to_mdanalysis(client.first_frame)\n",
     "    idx_array = universe.select_atoms(selection).indices\n",
     "    return map(int, idx_array)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 22
   },
   {
    "cell_type": "markdown",
@@ -616,20 +601,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:50.261018Z",
-     "start_time": "2024-10-11T11:03:50.253941Z"
+     "end_time": "2024-10-23T10:01:27.608296Z",
+     "start_time": "2024-10-23T10:01:27.604562Z"
     }
    },
-   "outputs": [],
    "source": [
     "root_selection = client.root_selection\n",
     "with root_selection.modify():\n",
     "    root_selection.hide = True\n",
     "    root_selection.interaction_method = 'none'"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 23
   },
   {
    "cell_type": "markdown",
@@ -640,32 +625,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:53.226476Z",
-     "start_time": "2024-10-11T11:03:53.219531Z"
+     "end_time": "2024-10-23T10:01:30.541878Z",
+     "start_time": "2024-10-23T10:01:30.538738Z"
     }
    },
-   "outputs": [],
    "source": [
     "protein = client.create_selection(\"Protein\", [])"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 24
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:54.671539Z",
-     "start_time": "2024-10-11T11:03:54.630624Z"
+     "end_time": "2024-10-23T10:01:34.598043Z",
+     "start_time": "2024-10-23T10:01:34.576039Z"
     }
    },
-   "outputs": [],
    "source": [
     "with protein.modify():\n",
     "    protein.set_particles(generate_mdanalysis_selection(\"protein and not type H\"))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 25
   },
   {
    "cell_type": "markdown",
@@ -680,14 +665,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:56.755224Z",
-     "start_time": "2024-10-11T11:03:56.733137Z"
+     "end_time": "2024-10-23T10:01:44.614764Z",
+     "start_time": "2024-10-23T10:01:44.601961Z"
     }
    },
-   "outputs": [],
    "source": [
     "with protein.modify():\n",
     "    protein.renderer = {\n",
@@ -700,7 +683,9 @@
     "            'scale': 0.2\n",
     "        }\n",
     "    protein.interaction_method = 'single'"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 26
   },
   {
    "cell_type": "markdown",
@@ -711,31 +696,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:58.254043Z",
-     "start_time": "2024-10-11T11:03:58.230434Z"
+     "end_time": "2024-10-23T10:01:47.248492Z",
+     "start_time": "2024-10-23T10:01:47.236891Z"
     }
    },
-   "outputs": [],
    "source": [
     "# Select ligand\n",
     "ligand = client.create_selection(\"Ligand\", [])\n",
     "with ligand.modify():\n",
     "    ligand.set_particles(generate_mdanalysis_selection(\"resname OSE\"))"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 27
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:03:59.744295Z",
-     "start_time": "2024-10-11T11:03:59.735321Z"
+     "end_time": "2024-10-23T10:01:48.826311Z",
+     "start_time": "2024-10-23T10:01:48.822512Z"
     }
    },
-   "outputs": [],
    "source": [
     "with ligand.modify():\n",
     "    ligand.renderer = {\n",
@@ -745,7 +728,9 @@
     "        }\n",
     "    ligand.velocity_reset = True\n",
     "    ligand.interaction_method = 'group'"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 28
   },
   {
    "cell_type": "markdown",
@@ -764,19 +749,24 @@
    ]
   },
   {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": "Once you are finished with the iMD simulation, it's good practice to close both the server and the clients that connect to it. You can close the python client and server by calling `.close()` on them:"
+  },
+  {
    "cell_type": "code",
-   "execution_count": 29,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-11T11:04:14.060954Z",
-     "start_time": "2024-10-11T11:04:14.056779Z"
+     "end_time": "2024-10-23T10:01:53.963071Z",
+     "start_time": "2024-10-23T10:01:53.523912Z"
     }
    },
-   "outputs": [],
    "source": [
     "client.close()\n",
     "imd_runner.close()"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 29
   },
   {
    "cell_type": "markdown",
@@ -789,7 +779,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "* Set up an OpenMM simulation of [graphene](./ase_openmm_graphene.ipynb) with restraints and add UI and custom commands in the notebook "
+    "In this tutorial, we demonstrated how to set up an OpenMM simulation, how to use that file to set up an iMD simulation using ASE (with an OpenMM calculator) to integrate the equations of motion, and how to alter the representation of the system for VR clients. From here, we recommend checking out the following tutorials:\n",
+    "* Set up an ASE/OpenMM simulation of [graphene](./ase_openmm_graphene.ipynb) with restraints and add UI and custom commands in the notebook.\n",
+    "* Learn how to perform iMD simulations using OpenMM with NanoVer by checking out the [NanoVer OpenMM tutorials](../openmm)."
    ]
   },
   {

--- a/examples/openmm/openmm_neuraminidase.ipynb
+++ b/examples/openmm/openmm_neuraminidase.ipynb
@@ -44,9 +44,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "We start by creating an OpenMM simulation from our AMBER files. OpenMM also supports Gromacs and CHARMM files, and can be customized for many other uses. "
-   ]
+   "source": "We start by creating an OpenMM simulation for the neuraminidase-oseltamivir system using the relevant pre-prepared AMBER files. OpenMM also supports Gromacs and CHARMM files, and can be customized for many other uses. "
   },
   {
    "cell_type": "code",
@@ -141,9 +139,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Now we create an OpenMM simulation from the topology, system and integrator that we have defined, and define the positions from the AMBER input coordinate file."
-   ]
+   "source": "Now we create an OpenMM simulation from the topology, system and integrator that we have defined, and define the positions using the AMBER input coordinate file."
   },
   {
    "cell_type": "code",
@@ -168,9 +164,7 @@
   {
    "cell_type": "markdown",
    "metadata": {},
-   "source": [
-    "Before we start the simulation, let's minimize the energy to create a stable conformation."
-   ]
+   "source": "Let's minimize the energy to create a stable conformation that can be used to run dynamics:"
   },
   {
    "cell_type": "code",


### PR DESCRIPTION
This PR aims to complete the remaining tasks in Issue #198, updating the notebooks to contain current information about how NanoVer works, use the correct simulation and runner classes, correct mistakes in the notebooks and improve the information present in the notebooks. 

One thing that has emerged from doing this is that it is unclear how the setup for the neuraminidase simulation in `ase_openmm_neuraminidase.ipynb` (which uses the ASESimulation) differs from the setup of an ASEOpenMMSimulation (as in the `ase_openmm_graphene.ipynb` notebook) apart from the fact that in the former the integrator parameters are explicitly set, which is not yet possible in the latter. 

I may be misunderstanding exactly what's going on, @Ragzouken is this correct? If so, it seems like it would be sensible to be able to set the simulation parameters in the ASEOpenMMSimulation, as I can't see a case where someone would want to run a simulation without defining the parameters they are using. This would mean we could either:

1. Move to using the ASEOpenMMSimulation class for the `ase_openmm_neuraminidase.ipynb`
2. Explain in the `ase_openmm_neuraminidase.ipynb` that the setup demonstrated there is equivalent to using ASEOpenMMSimulation (which it currently isn't)