### PR TITLE
Remove ASE OMM command line

### DIFF
--- a/python-libraries/nanover-ase/conda/meta.yaml
+++ b/python-libraries/nanover-ase/conda/meta.yaml
@@ -8,8 +8,6 @@ source:
 build:
   noarch: python
   number: 0
-  entry_points:
-    - nanover-omm-ase = nanover.ase.openmm.cli:main
 
 requirements:
   build:

--- a/python-libraries/nanover-ase/pyproject.toml
+++ b/python-libraries/nanover-ase/pyproject.toml
@@ -16,9 +16,6 @@ dependencies = [
 ]
 dynamic = ["version"]
 
-[project.scripts]
-nanover-omm-ase = "nanover.ase.openmm.cli:main"
-
 [tool.setuptools.packages.find]
 where = ["src"]  # list of folders that contain the packages (["."] by default)
 include = ["nanover.*"]  # package names should match these glob patterns (["*"] by default)

--- a/python-libraries/nanover-ase/src/nanover/ase/openmm/cli.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/openmm/cli.py
@@ -1,8 +1,0 @@
-def main():
-    print(
-        "This CLI has been discontinued, please use `nanover-omni --ase some_simulation.xml` instead."
-    )
-
-
-if __name__ == "__main__":
-    main()

--- a/python-libraries/nanover-omni/src/nanover/omni/cli.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/cli.py
@@ -41,16 +41,6 @@ def handle_user_arguments(args=None) -> argparse.Namespace:
     )
 
     parser.add_argument(
-        "--ase-omm",
-        dest="ase_xml_entries",
-        action="append",
-        nargs="+",
-        default=[],
-        metavar="PATH",
-        help="Simulation to run via ASE OpenMM (XML format)",
-    )
-
-    parser.add_argument(
         "--playback",
         dest="recording_entries",
         action="append",
@@ -126,12 +116,6 @@ def initialise_runner(arguments: argparse.Namespace):
 
         for path in get_all_paths(arguments.openmm_xml_entries):
             simulation = OpenMMSimulation.from_xml_path(path)
-            simulation.include_velocities = arguments.include_velocities
-            simulation.include_forces = arguments.include_forces
-            runner.add_simulation(simulation)
-
-        for path in get_all_paths(arguments.ase_xml_entries):
-            simulation = ASEOpenMMSimulation.from_xml_path(path)
             simulation.include_velocities = arguments.include_velocities
             simulation.include_forces = arguments.include_forces
             runner.add_simulation(simulation)

--- a/python-libraries/nanover-omni/src/nanover/omni/cli.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/cli.py
@@ -12,7 +12,6 @@ from typing import Iterable
 
 from nanover.omni import OmniRunner
 from nanover.omni.openmm import OpenMMSimulation
-from nanover.omni.ase_omm import ASEOpenMMSimulation
 from nanover.omni.playback import PlaybackSimulation
 from nanover.omni.record import record_from_server
 

--- a/python-libraries/nanover-omni/tests/test_cli.py
+++ b/python-libraries/nanover-omni/tests/test_cli.py
@@ -33,8 +33,6 @@ def test_cycle_multiple_sims():
             "0",
             "--omm",
             str(ARGON_XML_PATH),
-            "--ase-omm",
-            str(ARGON_XML_PATH),
             "--playback",
             str(RECORDING_PATH_TRAJ),
             str(RECORDING_PATH_STATE),


### PR DESCRIPTION
XML files are valid OMM systems and you don't have any of the benefits of using ASE in the CLI. The ASE OMM CLI also ignores the integrator settings which is confusing. Either use OMM CLI or set up ASE explicitly.

Closes https://github.com/IRL2/nanover-protocol/issues/208