### PR TITLE
Trigger update of submodules in `nanover-docs` repo

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -22,7 +22,7 @@ jobs:
           miniforge-version: latest
       - name: Set environment variables
         run: |
-          echo NANOVER_DOC_URL="https://irl2.github.io/nanover/" >> "$GITHUB_ENV"
+          echo NANOVER_DOC_URL="https://irl2.github.io/nanover-docs/" >> "$GITHUB_ENV"
           echo NANOVER_REPO_URL="https://github.com/IRL2/nanover-protocol" >> "$GITHUB_ENV"
           echo NANOVER_BUILD_VERSION="0.1.$(git rev-list --count HEAD)" >> "$GITHUB_ENV"
           echo NANOVER_LICENSE_PATH="$(readlink -f LICENSE)" >> "$GITHUB_ENV"

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -1,0 +1,20 @@
+name: "Notify docs repo to update submodules"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  trigger-submodule-update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger submodule update workflow in docs
+        env:
+          DOCS_UPDATE_TOKEN: ${{ secrets.DOCS_UPDATE_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Accept: application/vnd.github.v3+json" \
+            -H "Authorization: Bearer $DOCS_UPDATE_TOKEN" \
+            https://api.github.com/repos/IRL2/nanover-docs/actions/workflows/submodules.yml/dispatches \
+            -d '{"ref":"main"}'


### PR DESCRIPTION
This PR adds a workflow to the nanover-protocol repo to trigger a workflow in the nanover-docs repo that updates the submodules upon a push to main in nanover-protocol. This should close #7 and IRL2/nanover-docs#3.

In order to authenticate this workflow, a GitHub App (called "Update documentation submodules") has been created. This app has `Contents` permission (read and write) and `Workflows` permissions (read and write), and has access to both nanover-protocol and nanover-docs.

I don't know how to test this other than merging it into main to see if it triggers the desired workflows: @Ragzouken can you check the logic here? Feel free to edit/delete the app if there's something amiss here.