### PR TITLE
Add simulation time to FrameData for ASESimulation

### DIFF
--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -7,6 +7,7 @@ NanoVer clients.
 from typing import Iterable, Optional
 
 from ase import Atoms, Atom  # type: ignore
+from ase.units import fs as ase_units_to_fs
 import itertools
 import numpy as np
 import numpy.typing as npt
@@ -17,6 +18,8 @@ ANG_TO_NM = 0.1
 NM_TO_ANG = 1.0 / ANG_TO_NM
 KJMOL_TO_EV = 0.01036427
 EV_TO_KJMOL = 1.0 / KJMOL_TO_EV
+FS_TO_ASE_TIME_UNIT = ase_units_to_fs
+ASE_TIME_UNIT_TO_FS = 1.0 / FS_TO_ASE_TIME_UNIT
 
 # from https://chem.libretexts.org/Bookshelves/Physical_and_Theoretical_Chemistry_Textbook_Maps/Supplemental_Modules_(Physical_and_Theoretical_Chemistry)/Chemical_Bonding/Fundamentals_of_Chemical_Bonding/Covalent_Bond_Distance%2C_Radius_and_van_der_Waals_Radius
 # TODO make a helper class with complete coverage of this stuff.

--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -7,7 +7,7 @@ NanoVer clients.
 from typing import Iterable, Optional
 
 from ase import Atoms, Atom  # type: ignore
-from ase.units import fs as ase_units_to_fs
+from ase.units import fs as fs_in_ase_time_unit
 import itertools
 import numpy as np
 import numpy.typing as npt
@@ -18,7 +18,7 @@ ANG_TO_NM = 0.1
 NM_TO_ANG = 1.0 / ANG_TO_NM
 KJMOL_TO_EV = 0.01036427
 EV_TO_KJMOL = 1.0 / KJMOL_TO_EV
-FS_TO_ASE_TIME_UNIT = ase_units_to_fs
+FS_TO_ASE_TIME_UNIT = fs_in_ase_time_unit
 ASE_TIME_UNIT_TO_FS = 1.0 / FS_TO_ASE_TIME_UNIT
 
 # from https://chem.libretexts.org/Bookshelves/Physical_and_Theoretical_Chemistry_Textbook_Maps/Supplemental_Modules_(Physical_and_Theoretical_Chemistry)/Chemical_Bonding/Fundamentals_of_Chemical_Bonding/Covalent_Bond_Distance%2C_Radius_and_van_der_Waals_Radius

--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -18,8 +18,8 @@ ANG_TO_NM = 0.1
 NM_TO_ANG = 1.0 / ANG_TO_NM
 KJMOL_TO_EV = 0.01036427
 EV_TO_KJMOL = 1.0 / KJMOL_TO_EV
-FS_TO_ASE_TIME_UNIT = fs_in_ase_time_unit
-ASE_TIME_UNIT_TO_FS = 1.0 / FS_TO_ASE_TIME_UNIT
+PS_TO_ASE_TIME_UNIT = fs_in_ase_time_unit * 1e3
+ASE_TIME_UNIT_TO_PS = 1.0 / PS_TO_ASE_TIME_UNIT
 
 # from https://chem.libretexts.org/Bookshelves/Physical_and_Theoretical_Chemistry_Textbook_Maps/Supplemental_Modules_(Physical_and_Theoretical_Chemistry)/Chemical_Bonding/Fundamentals_of_Chemical_Bonding/Covalent_Bond_Distance%2C_Radius_and_van_der_Waals_Radius
 # TODO make a helper class with complete coverage of this stuff.

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -8,7 +8,11 @@ from ase.md import MDLogger
 from ase.md.md import MolecularDynamics
 
 from nanover.app import NanoverImdApplication
-from nanover.ase.converter import EV_TO_KJMOL, ASE_TIME_UNIT_TO_FS, ase_atoms_to_frame_data
+from nanover.ase.converter import (
+    EV_TO_KJMOL,
+    ASE_TIME_UNIT_TO_FS,
+    ase_atoms_to_frame_data,
+)
 from nanover.ase.imd_calculator import ImdCalculator
 from nanover.ase.wall_constraint import VelocityWallConstraint
 from nanover.trajectory import FrameData

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -8,7 +8,7 @@ from ase.md import MDLogger
 from ase.md.md import MolecularDynamics
 
 from nanover.app import NanoverImdApplication
-from nanover.ase.converter import EV_TO_KJMOL, ase_atoms_to_frame_data
+from nanover.ase.converter import EV_TO_KJMOL, ASE_TIME_UNIT_TO_FS, ase_atoms_to_frame_data
 from nanover.ase.imd_calculator import ImdCalculator
 from nanover.ase.wall_constraint import VelocityWallConstraint
 from nanover.trajectory import FrameData
@@ -171,6 +171,9 @@ class ASESimulation:
 
         # generate the next frame
         frame_data = self.make_regular_frame()
+
+        # Add simulation time to the frame
+        frame_data.simulation_time = self.dynamics.get_time() * ASE_TIME_UNIT_TO_FS
 
         # send the next frame
         self.app_server.frame_publisher.send_frame(self.frame_index, frame_data)

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -206,7 +206,7 @@ class ASESimulation:
         """
         assert self.atoms is not None
 
-        frame_data =  self.ase_atoms_to_frame_data(
+        frame_data = self.ase_atoms_to_frame_data(
             self.atoms,
             topology=False,
             include_velocities=self.include_velocities,

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -214,6 +214,7 @@ class ASESimulation:
         )
 
         # Add simulation time to the frame
-        frame_data.simulation_time = self.dynamics.get_time() * ASE_TIME_UNIT_TO_PS
+        if self.dynamics is not None:
+            frame_data.simulation_time = self.dynamics.get_time() * ASE_TIME_UNIT_TO_PS
 
         return frame_data

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -10,7 +10,7 @@ from ase.md.md import MolecularDynamics
 from nanover.app import NanoverImdApplication
 from nanover.ase.converter import (
     EV_TO_KJMOL,
-    ASE_TIME_UNIT_TO_FS,
+    ASE_TIME_UNIT_TO_PS,
     ase_atoms_to_frame_data,
 )
 from nanover.ase.imd_calculator import ImdCalculator
@@ -214,6 +214,6 @@ class ASESimulation:
         )
 
         # Add simulation time to the frame
-        frame_data.simulation_time = self.dynamics.get_time() * ASE_TIME_UNIT_TO_FS
+        frame_data.simulation_time = self.dynamics.get_time() * ASE_TIME_UNIT_TO_PS
 
         return frame_data

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -176,9 +176,6 @@ class ASESimulation:
         # generate the next frame
         frame_data = self.make_regular_frame()
 
-        # Add simulation time to the frame
-        frame_data.simulation_time = self.dynamics.get_time() * ASE_TIME_UNIT_TO_FS
-
         # send the next frame
         self.app_server.frame_publisher.send_frame(self.frame_index, frame_data)
         self.frame_index += 1
@@ -209,9 +206,14 @@ class ASESimulation:
         """
         assert self.atoms is not None
 
-        return self.ase_atoms_to_frame_data(
+        frame_data =  self.ase_atoms_to_frame_data(
             self.atoms,
             topology=False,
             include_velocities=self.include_velocities,
             include_forces=self.include_forces,
         )
+
+        # Add simulation time to the frame
+        frame_data.simulation_time = self.dynamics.get_time() * ASE_TIME_UNIT_TO_FS
+
+        return frame_data

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -8,7 +8,7 @@ from nanover.imd import ParticleInteraction
 from nanover.app import NanoverImdClient
 from nanover.omni import OmniRunner
 from nanover.omni.ase import ASESimulation
-from nanover.ase.converter import ASE_TIME_UNIT_TO_FS
+from nanover.ase.converter import ASE_TIME_UNIT_TO_PS
 
 from common import app_server
 
@@ -79,15 +79,15 @@ def test_simulation_time(example_ase_app_sim):
     simulation time (in fs).
     """
     # Check consistency of unit conversion:
-    assert (1.0 / ase_units.fs) == ASE_TIME_UNIT_TO_FS
+    assert (1.0 / (1e3 * ase_units.fs)) == ASE_TIME_UNIT_TO_PS
 
     app, sim = example_ase_app_sim
 
     # Advance simulation by 75 fs
     for _ in range(30):
         sim.advance_by_one_step()
-    time_elapsed = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_FS
-    assert time_elapsed == 75.0
+    time_elapsed = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS
+    assert time_elapsed == 75.0 * 1e-3
 
     with NanoverImdClient.connect_to_single_server(
         port=app.port, address="localhost"

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -89,6 +89,8 @@ def test_simulation_time(example_ase_app_sim):
     time_elapsed_ps = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS
     assert time_elapsed_ps == 75.0 * 1e-3
 
+    # Check that time delivered to client is the same as the time elapsed
+    # in the simulation
     with NanoverImdClient.connect_to_single_server(
         port=app.port, address="localhost"
     ) as client:

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -76,7 +76,7 @@ def test_dynamics_interaction(example_ase):
 def test_simulation_time(example_ase_app_sim):
     """
     Test that the simulation time delivered in the frame matches the elapsed
-    simulation time (in fs).
+    simulation time (in ps).
     """
     # Check consistency of unit conversion:
     assert (1.0 / (1e3 * ase_units.fs)) == ASE_TIME_UNIT_TO_PS

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -83,15 +83,15 @@ def test_simulation_time(example_ase_app_sim):
 
     app, sim = example_ase_app_sim
 
-    # Advance simulation by 75 fs
+    # Advance simulation by 75 fs (0.075 ps)
     for _ in range(30):
         sim.advance_by_one_step()
-    time_elapsed = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS
-    assert time_elapsed == 75.0 * 1e-3
+    time_elapsed_ps = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_PS
+    assert time_elapsed_ps == 75.0 * 1e-3
 
     with NanoverImdClient.connect_to_single_server(
         port=app.port, address="localhost"
     ) as client:
         client.subscribe_to_frames()
         client.wait_until_first_frame()
-        assert client.current_frame.simulation_time == time_elapsed
+        assert client.current_frame.simulation_time == time_elapsed_ps

--- a/python-libraries/nanover-omni/tests/test_ase.py
+++ b/python-libraries/nanover-omni/tests/test_ase.py
@@ -86,8 +86,8 @@ def test_simulation_time(example_ase_app_sim):
     # Advance simulation by 75 fs
     for _ in range(30):
         sim.advance_by_one_step()
-
     time_elapsed = sim.dynamics.get_time() * ASE_TIME_UNIT_TO_FS
+    assert time_elapsed == 75.0
 
     with NanoverImdClient.connect_to_single_server(
         port=app.port, address="localhost"


### PR DESCRIPTION
This PR adds the time elapsed during the simulation to the FrameData delivered to the user during an ASE simulation using the ASESimulation class. To do so requires a conversion from the [internal units of ASE](https://wiki.fysik.dtu.dk/ase/ase/units.html) to femtoseconds, and a subsequent conversion to picoseconds.