### PR TITLE
Fix units of NanoVer quantities in ASE simulations and deliver system and user forces separately

### DIFF
--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -113,9 +113,11 @@ def ase_to_frame_data(
     if box_vectors:
         add_ase_box_vectors_to_frame_data(data, ase_atoms)
     if include_velocities:
-        data.particle_velocities = ase_atoms.get_velocities() * (ANG_TO_NM / ASE_TIME_UNIT_TO_PS)
+        data.particle_velocities = ase_atoms.get_velocities() * (
+            ANG_TO_NM / ASE_TIME_UNIT_TO_PS
+        )
     if include_forces:
-        data.particle_forces = ase_atoms.get_forces() * (EV_TO_KJMOL / ANG_TO_NM)
+        data.particle_forces_system = ase_atoms.get_forces() * (EV_TO_KJMOL / ANG_TO_NM)
 
     return data
 

--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -115,7 +115,7 @@ def ase_to_frame_data(
     if include_velocities:
         data.particle_velocities = ase_atoms.get_velocities() * (ANG_TO_NM / ASE_TIME_UNIT_TO_PS)
     if include_forces:
-        data.particle_forces = ase_atoms.get_forces()
+        data.particle_forces = ase_atoms.get_forces() * (EV_TO_KJMOL / ANG_TO_NM)
 
     return data
 

--- a/python-libraries/nanover-ase/src/nanover/ase/converter.py
+++ b/python-libraries/nanover-ase/src/nanover/ase/converter.py
@@ -113,7 +113,7 @@ def ase_to_frame_data(
     if box_vectors:
         add_ase_box_vectors_to_frame_data(data, ase_atoms)
     if include_velocities:
-        data.particle_velocities = ase_atoms.get_velocities()
+        data.particle_velocities = ase_atoms.get_velocities() * (ANG_TO_NM / ASE_TIME_UNIT_TO_PS)
     if include_forces:
         data.particle_forces = ase_atoms.get_forces()
 

--- a/python-libraries/nanover-omni/src/nanover/omni/ase.py
+++ b/python-libraries/nanover-omni/src/nanover/omni/ase.py
@@ -230,6 +230,14 @@ class ASESimulation:
             )
             # Subtract the user energy from the potential energy
             frame_data.potential_energy -= frame_data.user_energy
+            # If the particle forces are included in the frame data, subtract
+            # the user forces to deliver the internal forces of the system
+            # and iMD forces separately (i.e. subtract the iMD forces from the
+            # total forces)
+            if self.include_forces:
+                frame_data.particle_forces_system -= (
+                    self.atoms.calc.results["interactive_forces"]
+                ) * (EV_TO_KJMOL / ANG_TO_NM)
         user_sparse_indices, user_sparse_forces = get_sparse_forces(
             self.atoms.calc.results["interactive_forces"]
         )


### PR DESCRIPTION
This PR corrects the units of the velocities and forces that were not being converted from ASE units to NanoVer units when being added to the FrameData for ASESimulations. In addition, this PR separates the user forces (resulting from iMD interactions) and system forces (resulting from interactions between the particles in the system) and delivers these separately in the frame, under the keys `particle_forces_system` and `user_forces`, respectively.

I have tested the changes made in this PR locally using a single Argon atom system, and comparing the results with those of an equivalent iMD simulation using the OpenMMSimulation class, which we know delivers the results correctly.